### PR TITLE
Complete FBN rewrite + Bitflag Util

### DIFF
--- a/templates/common/utils.h
+++ b/templates/common/utils.h
@@ -258,5 +258,15 @@ void ArrayMaxUInt( u32 array[], u32 count )
     return max;
 }
 
+typedef int Bitflag<read=FlagConvert(this),open=true>;                         
+int FlagConvert( int flag )
+{
+    if      (flag >= 0x50000000){ flag = (flag - 0x50000000) + 12288; }
+    else if (flag >= 0x40000000){ flag = (flag - 0x40000000) + 11776; }
+    else if (flag >= 0x30000000){ flag = (flag - 0x30000000) + 11264; }
+    else if (flag >= 0x20000000){ flag = (flag - 0x20000000) + 6144;  }
+    else if (flag >= 0x10000000){ flag = (flag - 0x10000000) + 3072;  }
+    return flag;
+}
 
 #endif // #ifndef UTILS_H


### PR DESCRIPTION
The FBN template has been rewritten. It now requires 010 Editor v12.0 or above for inline reads, and utils.h has also been updated to include a P5R bitflag datatype for all templates to use in the future. 

Redundant data type and function definitions in the old FBN template have been removed and replaced with a common include, hence the need for the Utils.h edit.  