### PR TITLE
Massive template updates for field research 

### DIFF
--- a/templates/common/utils.h
+++ b/templates/common/utils.h
@@ -4,7 +4,6 @@
 
 #include "common/types.h"
 
-
 void PrintValueUInt( string name, u64 value )
 {
     PrintValueUIntEx( name, value, true );
@@ -17,7 +16,7 @@ void PrintValueUIntEx( string name, u64 value, bool newline )
         PrintNl();
 }
 
-void PrintValueFloat( string name, f32 value )
+void PrintValueFloat( string name, u64 value )
 {
     PrintValueFloatEx( name, value, true );
 }
@@ -258,5 +257,15 @@ void ArrayMaxUInt( u32 array[], u32 count )
     return max;
 }
 
+typedef int Bitflag<read=FlagConvert(this),open=true>;                         
+int FlagConvert( int flag )
+{
+    if      (flag >= 0x50000000){ flag = (flag - 0x50000000) + 12288; }
+    else if (flag >= 0x40000000){ flag = (flag - 0x40000000) + 11776; }
+    else if (flag >= 0x30000000){ flag = (flag - 0x30000000) + 11264; }
+    else if (flag >= 0x20000000){ flag = (flag - 0x20000000) + 6144;  }
+    else if (flag >= 0x10000000){ flag = (flag - 0x10000000) + 3072;  }
+    return flag;
+}
 
 #endif // #ifndef UTILS_H

--- a/templates/p5_car.bt
+++ b/templates/p5_car.bt
@@ -1,0 +1,35 @@
+//------------------------------------------------
+//--- 010 Editor v12.0 Binary Template
+// File Mask: *.car
+// Authors: CherryCreamSoda
+//------------------------------------------------
+
+#include "common\include.h"
+BigEndian();
+
+void CherryRandomColor() {
+	SetBackColor( 518630000 + Random( 69420 ) );
+}
+
+typedef struct { f32 X; f32 Z; f32 Y; } CARPathNode <optimize=false,read=(Str("Position:    [ %g ]  [ %g ]  [ %g ]",X,Y,Z))>;
+
+typedef struct {
+    u32 EntryCount;
+    struct CAREntry Entry[EntryCount];
+} CARFile<optimize=false,read=(EntryCount)>;
+
+typedef struct {
+    CherryRandomColor();
+    char EntryTitle[32]<open=suppress>;
+    u32 PathNodeSize; 
+    u32 PathNodeCount;
+    CARPathNode PathNode[PathNodeCount];
+    Printf( "Entry %s Asserted Entry Size: %i - Real Entry Size: %i\n", EntryTitle, PathNodeSize, ( PathNodeCount * 12 + 4) );
+
+    if ( ( PathNodeCount * 12 + 4) < PathNodeSize ) {
+        SetBackColor( cGray );
+        u8 Dummy0[ PathNodeSize - ( PathNodeCount * 12 + 4)]<open=suppress>;
+    }
+} CAREntry<optimize=false,read=(EntryTitle)>;
+
+CARFile CAR<name=".CAR File">;

--- a/templates/p5_fbn.bt
+++ b/templates/p5_fbn.bt
@@ -1,366 +1,352 @@
 //------------------------------------------------
-//--- 010 Editor v8.0 Binary Template
-//
-//      File: p5_fbn.bt
-//   Authors: TGE, Cherry
-//   Version: 1.0
-//   Purpose: Parse Persona 5 FBN files
-//  Category: 
+//--- 010 Editor v12.0 Binary Template
 // File Mask: *.fbn
-//  ID Bytes: 
-//   History: 
+// Authors: CherryCreamSoda
 //------------------------------------------------
 
-//---------------------------------------------
-// Primitive types
-//---------------------------------------------
-typedef char bool;
-typedef char s8;
-typedef uchar u8;
-typedef int16 s16;
-typedef uint16 u16;
-typedef int16 s16;
-typedef int32 s32;
-typedef uint32 u32;
-typedef int64 s64;
-typedef uint64 u64;
-typedef float f32;
-typedef double f64;
+#include "common/include.h"
 
-//---------------------------------------------
-// Random color
-//---------------------------------------------
-local uint __RandomSeed = 0xDEADBABE;
-local uint __RandomBit = 0;
-local uint __RandomCount = 0;
- 
-uint MyRandom( uint to )
+void CherryRandomColor()
 {
-    ++__RandomCount;
-    __RandomBit  = ( (__RandomSeed >> 0 ) ^ ( __RandomSeed >> 2 ) ^ ( __RandomSeed >> 3 ) ^ ( __RandomSeed >> 5 ) ) & 1;
-    __RandomSeed = ( ( ( ( __RandomBit << 15 ) | ( __RandomSeed >> 1 ) ) + ( 0xBABE / __RandomCount ) ) % to );
-
-    while( __RandomSeed < 0 )
-        __RandomSeed += to;
-
-    return __RandomSeed;
+	SetBackColor( 518630000 + Random( 69420 ) );
 }
 
-uint RandomColor()
-{
-    return MyRandom( 0xFFFFFFFF );
-}
-
-void SetRandomBackColor()
-{
-    SetBackColor( RandomColor() );
-}
-
-// Generate s32 from FourCC in string format
-s32 FourCC( string str )
-{
-    return (s32)str[0] << 24 | (s32)str[1] << 16 | (s32)str[2] << 8 | (s32)str[3];
-}
-
-typedef struct
-{
-    f32 X;
-    f32 Y;
-    f32 Z;
-} Vector3;
-
-typedef struct
-{
-    f32 X;
-    f32 Y;
-    f32 Z;
-    f32 W;
-} Quaternion;
-
-typedef union
-{
-    s32 Int;
-    f32 Float;
-} IntFloat <read=IntFloatRead>;
-
-string IntFloatRead( IntFloat& value )
-{
-    char buffer[32];
-    s32 highBits = ( value.Int & 0xFF000000 );
-    bool isFloat = highBits >= 0x30000000 && highBits <= 0xD0000000;
-    if ( isFloat )
-    {
-        SPrintf( buffer, "%f", value.Float );
-    }
-    else
-    {
-        SPrintf( buffer, "%d", value.Int );
-    }
-
-    //SPrintf( buffer, "%d (%f)", value.Int, value.Float );
-    return buffer;
-}
-
-struct FbnBlock;
-struct FbnList;
+BigEndian();
 
 typedef enum<s32>
 {
-    FbnListType_Trigger = 1,
-    FbnListType_Entrance = 4,
-    FbnListType_Hit = 5,
-    FbnListType_Npc = 14,
-    FbnListType_Trigger2 = 19,
-    FbnListType_Trigger3 = 22
+    FBN_Trigger             = 1,
+    FBN_Entrance            = 4,
+    FBN_Hit                 = 5,
+    FBN_WanderShadow        = 8,
+    FBN_Chest               = 9,
+    FBN_Cover               = 10,
+    FBN_PatrolShadow        = 11,
+    FBN_MementosHit         = 12, //5 Dupe
+    FBN_MementosEntrance    = 13, // 4 Dupe
+    FBN_Npc                 = 14,
+    FBN_SearchObject        = 18,
+    FBN_SearchObjectHit     = 19,
+    FBN_WarningObject       = 21, // Lol, lmao
+    FBN_VoiceHit            = 22,
+    FBN_MementosEntrance_2  = 24, //13 Dupe
+    FBN_GrappleObject       = 25,
+    FBN_GrappleTrigger      = 26,
+    FBN_Header              = 1178750512
 } FbnListType;
+
+typedef struct( s32 Type )
+{
+    CherryRandomColor();
+	s32 EntryCount;
+	u32 Padding[3];
+    switch ( Type )
+    {
+        case FBN_Trigger:             struct FbnTriggerVolume Entry  [ EntryCount ]; break;
+        case FBN_Entrance:            struct FbnEntrance Entry       [ EntryCount ]; break;
+        case FBN_Hit:                 struct FbnHitDefinition Entry  [ EntryCount ]; break;
+        case FBN_WanderShadow:        struct FbnWanderShadow Entry   [ EntryCount ]; break;
+        case FBN_Chest:               struct FbnTreasureChest Entry  [ EntryCount ]; break;
+        case FBN_Cover:               struct FbnCoverPoints Entry    [ EntryCount ]; break;
+        case FBN_PatrolShadow:        struct FbnPatrolShadow Entry   [ EntryCount ]; break;
+        case FBN_MementosHit:         struct FbnTriggerVolume Entry  [ EntryCount ]; break; //Mementos Exclusive
+        case FBN_MementosEntrance:    struct FbnEntrance Entry       [ EntryCount ]; break; //Mementos Exclusive, not sure why 13 is just 24
+        case FBN_Npc:                 struct FbnNpc Entry            [ EntryCount ]; break;
+        case FBN_SearchObject:        struct FbnSearchObject Entry   [ EntryCount ]; break;
+        case FBN_SearchObjectHit:     struct FbnTriggerVolume Entry  [ EntryCount ]; break;
+        case FBN_WarningObject:       struct FbnWarningObject Entry  [ EntryCount ]; break; //Mementos Exclusive
+        case FBN_VoiceHit:            struct FbnTriggerVolume Entry  [ EntryCount ]; break;
+        case FBN_GrappleObject:       struct FbnGrappleObject Entry  [ EntryCount ]; break;
+        case FBN_GrappleTrigger:      struct FbnGrappleTrigger Entry [ EntryCount ]; break;
+        case FBN_MementosEntrance_2:  struct FbnEntrance Entry       [ EntryCount ]; break; //Mementos Exclusive
+        default: Printf( "[FbnList] Unhandled block entry Type: %d\n", Type );       break;
+    }
+} FbnList;
 
 typedef struct
 {
-    SetRandomBackColor();
+    CherryRandomColor();
     local s32 startOffset = FTell();
-
-	FbnListType Type;   // 'FBN0', 4, 1
-	s32 Version;       
-	s32 Size;           // Size of the block including this header
-	s32 ListOffset;     // Always 0x10 if not main header block
-
-    Assert( ListOffset == 0 || ListOffset == 0x10 );
-
-    if ( ListOffset != 0 ) 
+    FbnListType Type;
+    local string TypeEnumString = EnumToString(Type);
+    s32 Version;
+    s32 Size;
+    s32 ListOffset;
+    if ( ListOffset != 0 )
     {
         FbnList List( Type );
     }
-
     local s32 endOffset = startOffset + Size ;
     if ( FTell() < endOffset )
     {
-        Printf( "[FbnBlock] Reading %d left over bytes\n", endOffset - FTell() );
-        s8 RawData[ endOffset - FTell() ];
+        Printf( "[FbnBlock] Reading %d Bytes\n", endOffset - FTell() );
+        u8 RawData[ endOffset - FTell() ];
     }
-
     FSeek( endOffset );
-
-} FbnBlock <read=FbnBlockRead>;
+} FbnBlock <read = FbnBlockRead>;
 
 string FbnBlockRead( FbnBlock& block )
 {
     char buffer[32];
-    SPrintf( buffer, "Type %02d, Version 0x%08X", block.Type, block.Version );
+    if ( block.Type == 1178750512 )
+    {
+        SPrintf( buffer, "00 - %s :  v0x%08X", block.TypeEnumString, block.Version );
+    }
+    else
+    {
+        SPrintf( buffer, "%02d - %s :  v0x%08X", block.Type, block.TypeEnumString, block.Version );
+    }
     return buffer;
 }
 
-typedef struct( s32 type )
+//===========================================================================================================================================
+//  FBN BLOCK STRUCTURES START
+//===========================================================================================================================================
+
+typedef struct
 {
-    SetRandomBackColor();
-
-	s32 EntryCount;
-	s32 Padding[3];
-
-    Assert( Padding[0] == 0 );
-    Assert( Padding[1] == 0 );
-    Assert( Padding[2] == 0 );
-
-    switch ( type )
+    CherryRandomColor();
+    u32 Unk00;
+    local short TypeValue00 = ReadShort();
+    local short TypeValue01 = ReadShort(FTell()+2);
+    struct
     {
-        case FbnListType_Trigger: struct FbnTriggerVolume Entry[ EntryCount ]; break;
-        case FbnListType_Entrance: struct FbnEntrance Entry[ EntryCount ]; break;
-        case FbnListType_Hit: struct FbnHitDefinition Entry[ EntryCount ]; break;
-        case 8: struct FbnBlock8Entry Entry[ EntryCount ]; break;
-        case 9: struct FbnBlock9Entry Entry[ EntryCount ]; break;
-        case 10: struct FbnBlock10Entry Entry[ EntryCount ]; break;
-        case 11: struct FbnBlock11Entry Entry[ EntryCount ]; break;
-        case FbnListType_Npc: struct FbnNpc Entry[ EntryCount ]; break;
-        case 18: struct FbnBlock18Entry Entry[ EntryCount ]; break;
-        case FbnListType_Trigger2: struct FbnTriggerVolume Entry[ EntryCount ]; break;
-        case FbnListType_Trigger3: struct FbnTriggerVolume Entry[ EntryCount ]; break;
-        case 21: struct FbnBlock21Entry Entry[ EntryCount ]; break;
-
-        default:
-            Printf( "[FbnList] Unhandled block entry type: %d\n", type );
-            break;
-    }
-} FbnList;
-
-// Defines a volume for a trigger
-typedef struct
-{
-    SetRandomBackColor();
-
-    s16 Field00; // 0
-    s16 Field02; // 1
-    s16 Field04;
-    s16 Field06;
-    Vector3 Center;
-    f32 Field14;
-    f32 Field18;
-    f32 Field1C;
-    f32 Field20;
-    f32 Field24; // was 0, might be s32
-    f32 Field28; // was 0, might be s32
-    Vector3 BottomRight;
-    Vector3 TopRight;
-    Vector3 BottomLeft;
-    Vector3 TopLeft;
-    f32 Field5C; // was 0, might be s32
-    f32 Field60; // was 0, might be s32
-
-    Printf( "Field60=%d\n", Field60 );
-
-} FbnTriggerVolume <optimize=false>;
+        //int bit0 : 32;
+        
+        u8 bit00 : 1; u8 bit01 : 1; u8 bit02 : 1; u8 bit03 : 1; 
+        u8 bit04 : 1; u8 bit05 : 1; u8 bit06 : 1; u8 bit07 : 1; 
+        u8 bit08 : 1; u8 bit09 : 1; u8 bit10 : 1; u8 bit11 : 1;
+        u8 bit12 : 1; u8 bit13 : 1; u8 bit14 : 1; u8 bit15 : 1;
+        u8 bit16 : 1; u8 bit17 : 1; u8 bit18 : 1; u8 bit19 : 1;
+        u8 bit20 : 1; u8 bit21 : 1; u8 bit22 : 1; u8 bit23 : 1;
+        u8 bit24 : 1; u8 bit25 : 1; u8 bit26 : 1; u8 bit27 : 1;
+        u8 bit28 : 1; u8 bit29 : 1; u8 bit30 : 1; u8 bit31 : 1;
+        
+    } TypeIdentifier;
+    TVector3 Center;
+    f32 Unk01;
+    f32 Unk02;
+    f32 Unk03;
+    f32 Scale;
+    f32 Unk04;
+    f32 Unk05;
+    TVector3 BottomRight;
+    TVector3 TopRight;
+    TVector3 BottomLeft;
+    TVector3 TopLeft;
+    f32 Unk06;
+    f32 Unk07;
+} FbnTriggerVolume <optimize = false, read = ( Str( "Mode :  1 - %i - %i   ||   Position :  %g, %g, %g", TypeValue00, TypeValue01, Center.X, Center.Y, Center.Z ) )>;
 
 typedef struct
 {
-    SetRandomBackColor();
-    
-    s32 Field00;
-    s32 Field04;
-    Vector3 Position;
-    Vector3 Rotation;
-    s16 Id;
-    s16 Field22;
-
-} FbnEntrance <optimize=false>;
+    CherryRandomColor();
+    s32 Unk00;
+    s32 Unk01;
+    TVector3 Position;
+    TVector3 Rotation;
+    s16 EntranceID;
+    s16 Unk02;
+} FbnEntrance <optimize = false, read = ( Str( "Entrance :  %06i   ||   Position :  %g, %g, %g", EntranceID, Position.X, Position.Y, Position.Z ) )>;
 
 typedef struct
 {
-    s16 TitleTextId : 8;
-    s16 SubTitleTextId : 8;
-} FbnHitDefinitionTextIds;
-
-// Defines the hit/interaction info for a trigger volume
-// Each hit definition corresponds to an FBN trigger
-typedef struct
-{
-    LittleEndian();
-    s32 BitFlags[6] <comment="If bit flag is set, then hit is disabled">;
-    s8 Field18;
-    s8 PromptType <comment="Display prompt type (GO, Examine, Action, auto)">;
-    s16 TextId <comment="FTD text ID to display">;
-    s16 ProcedureId;
-    BigEndian();
-    s8 PromptSubType <comment="Used to display prompts like Shop">;
-    s8 Unused[29];
-} FbnHitDefinition <optimize=false>;
-
-typedef struct
-{
-    SetRandomBackColor();
-    
-    s32 Field00;
-    s16 Field04;
-    s16 Field06;
-    Vector3 Position;
-    f32 Field08[5];
-
-} FbnBlock8Entry <optimize=false>;
-
-typedef struct
-{
-    SetRandomBackColor();
-    
-    s32 Field00;
-    Vector3 Position;
-    f32 Field10[4]; // box coordinates maybe?
-    s16 Field20;
-    s16 Field22;
-    s16 Field24;
-    s16 Field26;
-
-} FbnBlock9Entry <optimize=false>;
+    CherryRandomColor();
+	struct
+	{
+		Bitflag TrueFlag<name = "Enabling Bitflag ">; //Adachi True!
+		Bitflag TrueFlag<name = "Enabling Bitflag ">;
+		Bitflag TrueFlag<name = "Enabling Bitflag ">;
+		Bitflag FalseFlag<name = "Disabling Bitflag ">;
+		Bitflag FalseFlag<name = "Disabling Bitflag ">;
+		Bitflag FalseFlag<name = "Disabling Bitflag ">;
+	} Bitflags <name = "Entry Bitflags">;
+    CherryRandomColor();
+    u8 PaddingByte;
+    u8 HitType;
+    u16 NameID;
+    u16 ProcedureIndex;
+    enum<short>
+    {
+        EXAMINE_fldCheckName0 = 0,
+        GO_Blank = 1,
+        EXAMINE_fldCheckName1 = 2,
+        EXAMINE_fldCheckName2 = 3,
+        EXAMINE_fldCheckName3 = 4,
+        EXAMINE_fldCheckName4 = 5,
+        STEAL_fldCheckName = 6,
+        ACTION_fldActionName0 = 7,
+        ACTION_fldActionName1 = 8,
+        ACTION_fldActionName2 = 9,
+        TALK_fldNPCName = 10,
+        GO_fldPlaceName = 11,
+        SHOP_fldCheckName = 12,
+        EXAMINE_fldKFECheckName = 13,
+    } PromptTypeList;
+    u32 UnusedValues[7];
+} FbnHitDefinition <optimize = false>;
 
 typedef struct
 {
-    SetRandomBackColor();
-
-    s32 Field00;
-    s32 Field04;
-    f32 Field08[24];
-    s32 Field68;
-    s32 Field6C;
-    s32 Field70;
-    s32 Field74;
-    s16 Field78;
-    s16 Field7A;
-    f32 Field7C[6];
-
-} FbnBlock10Entry <optimize=false>;
+    CherryRandomColor();
+    s32 Unk00;
+    s16 Unk01;
+    s16 Unk02;
+    TVector3 Position;
+    TVector3 Rotation;
+    f32 WanderRadius;
+    u32 Unk04;
+} FbnWanderShadow <optimize = false, read = ( Str( "Wander Radius :  %06g   ||   Position :  %g, %g, %g", WanderRadius, Position.X, Position.Y, Position.Z ) )>;
 
 typedef struct
 {
-    SetRandomBackColor();
-
-    s32 Field00;
-    f32 Field04;    
-    s32 Field08;
-    s32 Field0C;
-    s32 Field10;
-    s32 Field14;
-    s16 EntryCount;
-    s16 Field1A;
-    struct FbnBlock11SubEntry Entries[ EntryCount ];    
-
-} FbnBlock11Entry <optimize=false>;
-
-typedef struct
-{    
-    IntFloat Field00;
-    IntFloat Field04;
-    IntFloat Field08;
-    IntFloat Field0C;
-} FbnBlock11SubEntry;
+    CherryRandomColor();
+    s32 Unk00;
+    TVector3 Position;
+    TQuaternion Rotation;
+    s16 Model_MajorID;
+    s16 Model_MinorID;
+    u16 Chest_ResourceHandle;
+    s16 Unk01;
+} FbnTreasureChest <optimize = false, read = ( Str( "Model :  M%03i_%03i.GMD   ||   RESHND :  %i   ||   Position :  %g, %g, %g", Model_MajorID, Model_MinorID, Chest_ResourceHandle, Position.X, Position.Y, Position.Z ) )>;
 
 typedef struct
 {
-    SetRandomBackColor();
-
-	s32 Field00;        // always 1?
-	Vector3 Field04;     // 3F 80 00 00 BF 7F FF FF 00 00 00 00
-	Vector3 Field10;     // B2 59 FA A4 00 00 00 00 00 00 00 00
-	s16 Id;        // 0x6E, 0x2BE, 0x2BF, 0x2C0, 0x2C1, maybe object type?
-	s16 Field1E;        // always 0?
-	s32 Field20;        // always 1?
-    s32 Field24;
-	s32 Field28;        // 0xFFFFFFFF, 0
-	s16 PathNodeCount;  
-	s16 Field2E;        // always 0?
-	Vector3 PathNodes[ PathNodeCount ]; 
-} FbnNpc <optimize=false>;
-
-typedef struct
-{
-    SetRandomBackColor();
-
-    s32 Field00;
-    s16 Field04;
-    s16 Field06;
-    Vector3 Position;
-    Quaternion Rotation;
-    s16 Field24;
-    s16 Field26;
-    s16 Field28;
-    s16 Field2A;
-
-} FbnBlock18Entry <optimize=false>;
+    CherryRandomColor();
+    s32 Unk00;
+    s32 Unk01;
+    TVector3 Pos1_01;
+    TVector3 Pos1_02;
+    f32 Point1[6];
+    TVector3 Pos2_01;
+    TVector3 Pos2_02;
+    f32 Point2[6];
+    s32 Unk02;
+    s32 Unk03;
+    s32 Unk04;
+    s32 Unk05;
+    s16 Unk06;
+    s16 Unk07;
+    f32 Unk08[6];
+} FbnCoverPoints <optimize = false, read = ( Str( "Cover Start :  %g, %g, %g   ||   Cover End :  %g, %g, %g", Pos2_01.X, Pos2_01.Y, Pos2_01.Z, Pos2_02.X, Pos2_02.Y, Pos2_02.Z) )>;
 
 typedef struct
 {
-    SetRandomBackColor();
+    CherryRandomColor();
+    s32 Unk00;
+    f32 ShadowSpeed;
+    s32 Unk01;
+    s32 DoesShadowExist;
+    s32 Unk02;
+    s32 Unk03;
+    s16 PathNodeCount;
+    s16 Unk04;
+    TVector3 ShadowPathNode[ PathNodeCount ];
+    u32 Test[ PathNodeCount ];
+} FbnPatrolShadow <optimize = false, read = ( Str( "Patrol Speed:  %f   ||   Path Node Count :  %i", ShadowSpeed, PathNodeCount ) )>;
 
-    s32 Field00;
-    Vector3 Position;
-    Quaternion Rotation;
-    s16 Field20;
-    s16 Field22;
-    s16 Field24;
-    s16 Field26;
-    s16 Field28;
-    s16 Field2A;
-    s32 Field2C;
-    f32 Field30;
-    f32 Field34;
-} FbnBlock21Entry <optimize=false>;
+typedef struct
+{
+    CherryRandomColor();
+	s32 Unk00;
+	f32 Unk01;
+	TVector3 NPCRotation<comment = "Last column of complex rotation matrix">;
+	f32 Unk02;
+	f32 Unk03;
+	s16 FNT_ID;
+	s16 Unk04;
+	s32 Unk05;
+    s32 Unk06;
+	s32 Unk07;
+	s16 PathNodeCount;
+	s16 Unk08;
+	TVector3 PathNodes[ PathNodeCount ];
+} FbnNpc <optimize = false, read = ( Str( "FNT ID :  %03i   ||   Path Node Count :  %i", FNT_ID, PathNodeCount ) )>;
 
-BigEndian();
+typedef struct
+{
+    CherryRandomColor();
+    s32 Unk00;
+    s16 Unk01;
+    s16 Unk02;
+    TVector3 Position;
+    TQuaternion Rotation;
+    s16 Model_MajorID;
+    s16 Model_MinorID;
+    u16 SearchObject_ResourceHandle;
+    s16 Unk03;
+} FbnSearchObject <optimize = false, read = ( Str( "Model :  M%03i_%03i.GMD   ||   RESHND :  %i   ||   Position :  %g, %g, %g", Model_MajorID, Model_MinorID, SearchObject_ResourceHandle, Position.X, Position.Y, Position.Z ) )>;
+
+typedef struct
+{
+    CherryRandomColor();
+    s32 Unk00;
+    TVector3 Position;
+    TQuaternion Rotation;
+    s16 Unk01;
+    s16 Unk02;
+    s16 Model_MajorID;
+    s16 Model_MinorID;
+    u16 Gimmick_ResourceHandle;
+    s16 Unk03;
+    s32 Unk04;
+    f32 ActiveTimer;
+    f32 InactiveTime;
+} FbnWarningObject <optimize = false, read = ( Str( "Model :  M%03i_%03i.GMD   ||   RESHND :  %i   ||   Position :  %g, %g, %g", Model_MajorID, Model_MinorID, Gimmick_ResourceHandle, Position.X, Position.Y, Position.Z ) )>;
+
+typedef struct
+{
+    CherryRandomColor();
+    u32 Unk00;
+    bool JumpAfterGrapple;
+    bool JumpAfterGrapple2;
+    s16 Wire_SequenceID;
+    TVector3 Position;
+    TQuaternion Rotation;
+    s16 Model_MajorID;
+    s16 Model_MinorID;
+    u16 Grapple_ResourceHandle;
+    u16 Unk01;
+    u16 JumpLength;
+    u16 JumpHeight;
+} FbnGrappleObject <optimize = false, read = ( Str(  "Model :  M%03i_%03i.GMD   ||   RESHND :  %i   ||   Sequence ID :  %i   ||   Position :  %g, %g, %g", Model_MajorID, Model_MinorID, Grapple_ResourceHandle, Wire_SequenceID, Position.X, Position.Y, Position.Z  ) )>;
+
+typedef struct
+{
+    CherryRandomColor();
+    u32 Unk00;
+    local short TypeValue00 = ReadShort();
+    local short TypeValue01 = ReadShort(FTell()+2);
+    struct
+    {
+        //int bit0 : 32;
+        
+        u8 bit00 : 1; u8 bit01 : 1; u8 bit02 : 1; u8 bit03 : 1; 
+        u8 bit04 : 1; u8 bit05 : 1; u8 bit06 : 1; u8 bit07 : 1; 
+        u8 bit08 : 1; u8 bit09 : 1; u8 bit10 : 1; u8 bit11 : 1;
+        u8 bit12 : 1; u8 bit13 : 1; u8 bit14 : 1; u8 bit15 : 1;
+        u8 bit16 : 1; u8 bit17 : 1; u8 bit18 : 1; u8 bit19 : 1;
+        u8 bit20 : 1; u8 bit21 : 1; u8 bit22 : 1; u8 bit23 : 1;
+        u8 bit24 : 1; u8 bit25 : 1; u8 bit26 : 1; u8 bit27 : 1;
+        u8 bit28 : 1; u8 bit29 : 1; u8 bit30 : 1; u8 bit31 : 1;
+        
+    } TypeIdentifier;
+    u16 Grapple_ResourceHandle;
+    s16 Unk03;
+    TVector3 Center;
+    f32 Unk04;
+    f32 Unk05;
+    f32 Unk06;
+    f32 Scale;
+    f32 Unk07;
+    f32 Unk08;
+    TVector3 BottomRight;
+    TVector3 TopRight;
+    TVector3 BottomLeft;
+    TVector3 TopLeft;
+    u16 Unk09;
+    u16 Unk10;
+} FbnGrappleTrigger <optimize = false, read = ( Str( "Mode :  1 - %i - %i   ||   RESHND :  %i   ||   Position :  %g, %g, %g", TypeValue00, TypeValue01, Grapple_ResourceHandle, Center.X, Center.Y, Center.Z ) )>;
+
 while ( !FEof() )
     FbnBlock Block;
-

--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -2,14 +2,20 @@
 //--- 010 Editor v8.0 Binary Template
 //
 //      File: p5_gfd.bt
-//   Authors: 
-//   Version: 
+//   Authors:
+//   Version:
 //   Purpose: GFD
 //  Category: Persona 5
 // File Mask: *.gmd, *.gap, *.epl, *.bed, *.gfs
 //  ID Bytes: GFS0
-//   History: 
+//   History:
 //------------------------------------------------
+
+//
+// --- Template options
+//
+//#define CFB_GAP
+//#define CFB_GFS
 
 #include "common/include.h"
 #include "p5_gfd_enums.bt"
@@ -56,7 +62,7 @@ string TChunkHeaderToString( TChunkHeader& value )
 typedef struct
 {
     u16 Length;
-    char Str[Length];  
+    char Str[Length];
 } TString <optimize=false, read=TStringToString>;
 
 string TStringToString( TString& value )
@@ -64,28 +70,92 @@ string TStringToString( TString& value )
     return value.Str;
 }
 
+local uint sHashTable[256] =
+{
+  0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
+  0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91,
+  0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7,
+  0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5,
+  0x3B6E20C8, 0x4C69105E, 0xD56041E4, 0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B,
+  0x35B5A8FA, 0x42B2986C, 0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59,
+  0x26D930AC, 0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
+  0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D,
+  0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433,
+  0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, 0x91646C97, 0xE6635C01,
+  0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457,
+  0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65,
+  0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB,
+  0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
+  0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
+  0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, 0xB7BD5C3B, 0xC0BA6CAD,
+  0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683,
+  0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1,
+  0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7,
+  0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5,
+  0xD6D6A3E8, 0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
+  0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF, 0x4669BE79,
+  0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F,
+  0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D,
+  0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A, 0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713,
+  0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21,
+  0x86D3D2D4, 0xF1D4E242, 0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777,
+  0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
+  0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB,
+  0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
+  0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693, 0x54DE5729, 0x23D967BF,
+  0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D
+};
+
+uint BitwiseRotateLeft( uint x, int amount )
+{
+  return ( x << amount ) | ( x >> ( ( 32 - amount ) & 31 ) );
+}
+
+int GenerateStringHash( char value[] )
+{
+  local uint len = Strlen( value );
+
+  if ( !len )
+    return 0;
+
+  local uint hash = len;
+
+  local int i;
+  local uint tableIdx;
+
+  for ( i = 0; i < len; i++ )
+  {
+    tableIdx = hash ^ ( byte )( value[i] );
+    tableIdx = ( BitwiseRotateLeft( tableIdx, 2 ) & 0x000003FC ) / sizeof( uint );
+    hash = BitwiseRotateLeft( hash, 24 ) & 0x00FFFFFF;
+    hash ^= sHashTable[tableIdx];
+  }
+
+  return ( int )hash;
+}
+
 typedef struct(u32 version)
 {
-    u16 Length;
-    if ( Length )
+  u16 Length;
+
+  if ( Length )
+  {
+    char Str[Length];
+
+    if ( version > 0x01080000 )
     {
-        char Str[Length];  
-    
-        if ( version >= 0x01105100 )
-        {
-            u8 CFBOnlyPaddingByte;
-            if (CFBOnlyPaddingByte != 0)
-            {
-                FSeek(FTell() - 1);
-            }
-        }
-        
-        if ( version > 0x1080000 )
-        {
-            // hash
-            u32 Hash;
-        }
-    }  
+
+#ifdef CFB_GAP
+      if ( version >= 0x01105100 )
+      {
+        u8 CFBOnlyPaddingByte;
+      }
+#endif
+
+      // hash
+      u32 Hash;
+    }
+  }
 } THashString <optimize=false, read=THashStringToString>;
 
 string THashStringToString( THashString& value )
@@ -94,7 +164,8 @@ string THashStringToString( THashString& value )
         return "<empty string>";
 
     string buffer;
-    SPrintf( buffer, "%s (%08X)", value.Str, value.Hash );
+    SPrintf( buffer, "%s (%08X) [%08X]", value.Str, value.Hash, GenerateStringHash( value.Str ) );
+
     return buffer;
 }
 
@@ -103,14 +174,14 @@ typedef struct(u32 version)
     u16 Length;
     if ( Length )
     {
-        char Str[Length];  
-    
+        char Str[Length];
+
         if ( version > 0x1080000 )
         {
             // hash
             u32 Hash;
-        }    
-    } 
+        }
+    }
 } THashStringNoPad <optimize=false>;
 
 typedef struct(u32 version)
@@ -188,7 +259,7 @@ typedef struct
     u8 Field1C;
     u8 Field1D;
     u8 Field1E;
-    u8 Field1F; 
+    u8 Field1F;
 } TTexture <optimize=false, read=TTextureToString>;
 
 string TTextureToString( TTexture& value )
@@ -203,7 +274,7 @@ typedef struct
     SetRandomBackColor();
 
     TChunkHeader Header;
-    Assert( Header.Type == EChunkType_TextureDictionary ); 
+    Assert( Header.Type == EChunkType_TextureDictionary );
 
     u32 TextureCount;
     if ( TextureCount > 0 )
@@ -223,7 +294,7 @@ typedef struct
     SetRandomBackColor();
 
     TChunkHeader Header;
-    Assert( Header.Type == EChunkType_MaterialDictionary ); 
+    Assert( Header.Type == EChunkType_MaterialDictionary );
 
     u32 MaterialCount;
     struct TMaterial Materials( Header.Version )[MaterialCount];
@@ -266,7 +337,7 @@ typedef struct
 } TMaterialFlags;
 
 typedef struct
-{ 
+{
     EMaterialMapsTexcoord Filler           : 5<hidden=true>;
     EMaterialMapsTexcoord ShadowMap        : 3;
     EMaterialMapsTexcoord DetailMap        : 3;
@@ -285,8 +356,8 @@ typedef struct(u32 version)
 
     THashString Name( version );
     local EMaterialFlags Flags;
-	TMaterialFlags MaterialFlags;
-    
+    TMaterialFlags MaterialFlags;
+
     if ( version < 0x1104000 )
     {
         local EMaterialFlags RuntimeFlags = ( EMaterialFlags )( ( u32 )Flags & 0x7FFFFFFF );
@@ -296,8 +367,8 @@ typedef struct(u32 version)
     TVector4 DiffuseColor;
     TVector4 SpecularColor;
     TVector4 EmissiveColor;
-    f32 Field40;
-    f32 Field44;
+    f32 matReflectivity;
+    f32 matOutlineIndex;
 
     if ( version <= 0x1103040 )
     {
@@ -307,10 +378,10 @@ typedef struct(u32 version)
         s16 Field4A;
         s16 Field4B;
         s16 Field4C;
-        
+
         if ( version > 0x108011B )
         {
-           s16 Field4D; 
+            s16 Field4D;
         }
     }
     else
@@ -320,12 +391,12 @@ typedef struct(u32 version)
         u8 Field4A;
         u8 Field4B;
         u8 Field4C;
-        u8 Field4D; 
+        u8 Field4D;
     }
 
     s16 Field90;
     s16 Field92;
-    
+
     if ( version <= 0x1104800 )
     {
         local s16 Field94 = 1;
@@ -340,10 +411,12 @@ typedef struct(u32 version)
     s16 Field5C;
     TMaterialMapsTexcoord TexcoordFlags;
     TMaterialMapsTexcoord TexcoordFlags;
-	if ( version <= 0x01104800 )
-	{
-		u16 Field74;
-	}
+
+    if ( version <= 0x01104800 )
+    {
+        u16 Field74;
+    }
+
     TBool16 DisableBackfaceCulling;
     u32 Field98<format=hex>;
 
@@ -369,7 +442,7 @@ typedef struct(u32 version)
         {
             attributeStart = FTell();
             attributeHeader = ReadInt( attributeStart );
-            
+
             switch ( ( enum EMaterialAttributeType )( attributeHeader & 0xFFFF ) )
             {
                 case EMaterialAttributeType_ToonShading: struct TMaterialAttributeToonShading Attribute( version ); break;
@@ -483,28 +556,28 @@ typedef struct(u32 version)
     if ( version > 0x1104500 )
     {
         TVector4 Color;
-        f32 Field1C;
-        f32 Field20;
-        f32 Field24;
-        f32 Field28;
-        f32 Field2C;
+        f32 toonLightThrehold;
+        f32 toonLightFactor;
+        f32 toonLightBrightness;
+        f32 toonShadowThreshold;
+        f32 toonShadowFactor;
         local EMaterialAttributeToonShadingFlags Flags;
         TMaterialAttributeToonShadingFlags MaterialFlags;
     }
     else if ( version > 0x1104220 )
     {
         TVector4 Color;
-        f32 Field1C;
-        f32 Field20;
-        f32 Field24;
-        f32 Field28;
-        f32 Field2C;
+        f32 toonLightThrehold;
+        f32 toonLightFactor;
+        f32 toonLightBrightness;
+        f32 toonShadowThreshold;
+        f32 toonShadowFactor;
 
         local EMaterialAttributeToonShadingFlags Flags;
         bool Flag1;
         bool Flag2;
         bool Flag4;
-        
+
         if ( Version > 0x1102460 )
         {
             bool Flag8;
@@ -528,11 +601,11 @@ typedef struct(u32 version)
     else
     {
         TVector4 Color;
-        f32 Field1C;
-        f32 Field20;
-        local f32 Field24 = 1.0f;
-        f32 Field28;
-        f32 Field2C;
+        f32 toonLightThrehold;
+        f32 toonLightFactor;
+        f32 toonLightBrightness;
+        f32 toonShadowThreshold;
+        f32 toonShadowFactor;
     }
 } TMaterialAttributeToonShading <optimize=false>;
 
@@ -689,6 +762,10 @@ typedef struct(u32 version)
     TMaterialAttributeHeader Header;
     Assert( Header.Type == EMaterialAttributeType_Type8 );
 
+#ifndef CFB_GFS
+    f32 Field00;
+    u32 Field04;
+#else
     TVector3 Field00;
     f32 Field0C;
     f32 Field10;
@@ -701,6 +778,8 @@ typedef struct(u32 version)
     s32 Field34;
     s32 Field38;
     EMaterialAttributeType8Flags Flags;
+#endif
+
 } TMaterialAttributeType8;
 
 //
@@ -717,7 +796,7 @@ typedef struct
 
     TChunkHeader Header;
     EModelFlags Flags;
-    
+
     if ( Flags & EModelFlags_HasSkinning )
     {
         SetBackColorToShadeOfLastColor(0x20);
@@ -732,14 +811,14 @@ typedef struct
     {
         SetBackColorToShadeOfLastColor(0x20);
         TExtents3D BoundingBox;
-    }   
+    }
 
     if ( Flags & EModelFlags_HasBoundingSphere )
     {
         SetBackColorToShadeOfLastColor(0x20);
         TSphere3D BoundingSphere;
     }
-    
+
     struct TNode RootNode( Header.Version );
 } TModel <optimize=false>;
 
@@ -751,7 +830,7 @@ typedef struct( u32 version )
     TVector3 Translation;
     TQuaternion Rotation;
     TVector3 Scale;
-    
+
     if ( version <= 0x1090000 )
     {
         u8 Unknown1;
@@ -774,7 +853,7 @@ typedef struct( u32 version )
     {
         f32 FieldE0;
     }
-    
+
     u32 ChildCount;
     if ( ChildCount > 0 )
         struct TNode Children( version )[ChildCount];
@@ -822,7 +901,7 @@ typedef struct(u32 version)
 {
     EMeshFlags Flags;
     EVertexAttributeFlags VertexAttributeFlags;
-    
+
     if ( Flags & EMeshFlags_HasTriangles )
     {
         u32 TriangleCount;
@@ -830,12 +909,12 @@ typedef struct(u32 version)
     }
 
     u32 VertexCount;
-    
+
     if ( version > 0x1103020 )
     {
-        u32 Field14;
+        u32 InvisShadowCaster;
     }
-    
+
     struct TVertex Vertices( Flags, VertexAttributeFlags )[VertexCount];
 
     if ( Flags & EMeshFlags_HasMorphTargets )
@@ -930,12 +1009,12 @@ typedef struct( u32 version )
     {
         ELightFlags Flags;
     }
-    
+
     ELightType Type;
     TVector4 AmbientColor;
     TVector4 DiffuseColor;
     TVector4 SpecularColor;
-    
+
     switch ( Type )
     {
         case ELightType_Type1:
@@ -951,12 +1030,12 @@ typedef struct( u32 version )
             f32 AngleInnerCone; // 0.08377809
             f32 AngleOuterCone; // 0.245575309
             // fallthrough
-    
+
         case ELightType_Point:
             f32 Field10; // 0
             f32 Field04; // 0
             f32 Field08; // 0
-    
+
             if ( Flags & ELightFlags_Bit2 )
             {
                 f32 AttenuationStart; // attenuation start?
@@ -992,7 +1071,7 @@ typedef struct
     SetRandomBackColor();
 
     TChunkHeader Header;
-    
+
     if ( Header.Version > 0x1104950 )
     {
         EAnimationPackFlags Flags;
@@ -1025,13 +1104,16 @@ typedef struct( u32 version )
 
     f32 Duration;
     u32 ControllerCount;
-    if ( version > 0x01105100 )
+
+#ifdef CFB_GAP
+    if ( version >= 0x01105100 )
     {
         s32 Unknown1;
         s32 Unknown2;
         Assert( Unknown1 == ControllerCount );
     }
-    
+#endif
+
     if ( ControllerCount )
     {
         struct( u32 version )
@@ -1039,7 +1121,7 @@ typedef struct( u32 version )
             struct TAnimationController Controllers( version )[ ControllerCount ];
         } Controllers( version );
     }
-    
+
     if ( Flags & EAnimationFlags_Flag10000000 )
         struct TAnimationFlagsFlag10000000Data Flag10000000Data( version );
 
@@ -1099,8 +1181,14 @@ typedef struct( u32 version )
     SetRandomBackColor();
 
     ETargetKind TargetKind;
-    s32 TargetId;
+    s32 TargetId<format=hex>;
     THashString TargetName( version );
+    /*
+    if ( TargetId > 100000 )
+    {
+        Printf("EPL Controller ID: %x\n", TargetId);
+    }
+    */
     u32 LayerCount;
     struct TAnimationLayer Layers( version )[ LayerCount ];
 } TAnimationController <optimize=false>;
@@ -1108,41 +1196,41 @@ typedef struct( u32 version )
 typedef struct( u32 version )
 {
     SetRandomBackColor();
-    
+
     EKeyType KeyType;
     u32 KeyCount;
-    
+
     if ( KeyCount > 0 )
     {
         f32 KeyTimings[ KeyCount ];
-        
+
         switch ( KeyType )
         {
             case EKeyType_NodePR: struct TNodePRKey Keys[ KeyCount ]; break;
             case EKeyType_NodePRS: struct TNodePRSKey Keys[ KeyCount ]; break;
-        
+
             case EKeyType_NodePRHalf_2:
-            case EKeyType_NodePRHalf: 
-                struct TNodePRHalf Keys[ KeyCount ]; 
+            case EKeyType_NodePRHalf:
+                struct TNodePRHalf Keys[ KeyCount ];
                 break;
-        
+
             case EKeyType_NodePRSHalf: struct TNodePRSHalf Keys[ KeyCount ]; break;
             case EKeyType_NodeRHalf: struct TNodeRHalf Keys[ KeyCount ]; break;
             case EKeyType_NodeSHalf: struct TNodeSHalf Keys[ KeyCount ]; break;
-        
+
             case EKeyType_Vector3:
-            case EKeyType_Vector3_2: 
+            case EKeyType_Vector3_2:
             case EKeyType_Vector3_3:
             case EKeyType_Vector3_4:
             case EKeyType_MaterialVector3_5:
                 struct TVector3Key Keys[ KeyCount ];
                 break;
-        
+
             case EKeyType_Quaternion:
             case EKeyType_Quaternion_2:
                 struct TQuaternionKey Keys[ KeyCount ];
                 break;
-        
+
             case EKeyType_Single:
             case EKeyType_Single_2:
             case EKeyType_Single_3:
@@ -1156,21 +1244,22 @@ typedef struct( u32 version )
             case EKeyType_SingleAlt_3:
                 struct TSingleKey Keys[ KeyCount ];
                 break;
-        
+
             case EKeyType_Single5:
             case EKeyType_Single5_2:
             case EKeyType_Single5Alt:
-                struct TSingle5Key Keys[ KeyCount ]; 
+            case 36:
+                struct TSingle5Key Keys[ KeyCount ];
                 break;
-        
+
             case EKeyType_PRSByte: struct TPRSByteKey Keys[ KeyCount ]; break;
             case EKeyType_Single3Byte: struct TSingle3ByteKey Keys[ KeyCount ]; break;
             case EKeyType_SingleByte: struct TSingleByteKey Keys[ KeyCount ]; break;
             case EKeyType_Type22: struct TKeyType22 Keys[ KeyCount ]; break;
-        
+
             case EKeyType_Type31:
                 {
-                    if ( version < 0x01105100 )
+                    if ( version <= 0x01105100 )
                     {
                         struct TKeyType31Dancing Keys[ KeyCount ];
                     }
@@ -1180,28 +1269,28 @@ typedef struct( u32 version )
                     }
                 }
                 break;
-				
+
 			// P5R keys
 			case 34: struct TKeyType34P5R Keys [ KeyCount ]; break;
-			//case 34: byte UnkKeyType [ KeyCount*12 ]; break;
+
 			case 35: struct TKeyType35P5R Keys [ KeyCount ]; break;
-			
+
             default:
 			    local string buffer;
                 SPrintf( buffer, "Unknown/Invalid Key frame type %01d", KeyType );
                 Assert( false, buffer );
         }
-        
+
          // Read scale values for compressed keys
         if ( KeyType == EKeyType_NodePRHalf   || KeyType == EKeyType_NodePRSHalf ||
              KeyType == EKeyType_NodePRHalf_2 || KeyType == EKeyType_Type31 ||
-             KeyType == EKeyType_NodeRHalf    || KeyType == EKeyType_NodeSHalf || 
+             KeyType == EKeyType_NodeRHalf    || KeyType == EKeyType_NodeSHalf ||
 			 KeyType == EKeyType_34P5R        || KeyType == EKeyType_35P5R      )
         {
             TVector3 PositionScale;
-            
-            if ( version < 0x01105100 || KeyType != EKeyType_Type31)
-                TVector3 ScaleScale;
+
+            //if ( version < 0x01105100 || KeyType != EKeyType_Type31)
+            TVector3 ScaleScale;
         }
     }
 } TAnimationLayer <optimize=false>;
@@ -1254,7 +1343,6 @@ typedef struct { TVector3 Value; } TVector3Key;
 typedef struct { TQuaternion Value; } TQuaternionKey;
 typedef struct { f32 Value; } TSingleKey;
 typedef struct { f32 Field00; u8 Field04; } TSingleByteKey;
-typedef struct { f32 Values[5]; } TSingle5Key;
 
 typedef struct
 {
@@ -1302,6 +1390,15 @@ typedef struct
     u8 Data[ 0x1C ];
 } TKeyType31FullBody;
 
+typedef struct { 
+
+    f32 XOffset; 
+    f32 YOffset;
+    f32 XScale;
+    f32 YScale;
+    f32 UVRotation;
+} TSingle5Key;
+
 //
 // -- End Animation types
 //
@@ -1318,7 +1415,7 @@ typedef struct( u32 version )
     EEplFlags Flags;
     TNode RootNode( version );
     struct TEplAnimation Animation( version );
-    
+
     if ( version > 0x1105060 )
     {
         u16 Field40;
@@ -1330,6 +1427,7 @@ typedef struct( u32 version )
 local u32 keyCountsBuffer[1024];
 typedef struct( u32 version )
 {
+    Printf("\n|| < AnimStruct: %i >\n", FTell());
     SetRandomBackColor();
 
     u32 Field00;
@@ -1339,8 +1437,6 @@ typedef struct( u32 version )
 
     local u32 i;
     local u32 controllerCount = Animation.ControllerCount;
-    //for ( i = 0; i < controllerCount; ++i )
-    //    keyCountsBuffer[i] = Animation.Controllers.Controllers[i].Layers[0].KeyCount;
 
     struct TEplAnimationController Controllers( version, keyCountsBuffer )[ Field10 ];
 } TEplAnimation  <optimize=false>;
@@ -1349,7 +1445,7 @@ typedef struct( u32 version, u32 keyCounts[] )
 {
     SetRandomBackColor();
 
-    f32 Field00;  
+    f32 Field00;
     f32 Field04;
     s32 ControllerIndex; // 0x08
 
@@ -1357,10 +1453,10 @@ typedef struct( u32 version, u32 keyCounts[] )
     {
         //local u32 keyCount = Animation.Controller[ControllerIndex].KeyCount;
         local u32 keyCount = keyCounts[ControllerIndex];
-    
+
         if ( keyCount != 0 )
         {
-            struct TEplAnimationKey Keys[keyCount]; 
+            struct TEplAnimationKey Keys[keyCount];
         }
     }
 
@@ -1369,34 +1465,35 @@ typedef struct( u32 version, u32 keyCounts[] )
 
 typedef struct( u32 version )
 {
+
     SetRandomBackColor();
-
+    Printf("\n|| Node Location: %12u || Name: ", FTell());
     EEplLeafFlags Flags; // 0x2C
+    Printf("%14s || Type: ",ReadString(FTell()+2,ReadUByte(FTell()+1)));
     THashString Name( version ); // 0x30
-
     local u32 type = ReadInt( FTell() + 0 );
-    
+
     // 0x40
     switch ( type )
     {
-        case 0: struct TEplDummy Data( version ); break;
-        case 1: struct TEplParticle Data( version ); break;
-        case 2: struct TEplFlashPolygon Data( version ); break;
-        case 3: struct TEplCirclePolygon Data( version ); break;
-        case 4: struct TEplLightningPolygon Data( version ); break;
-        case 5: struct TEplTrajectoryPolygon Data( version ); break;
-        case 6: struct TEplWindPolygon Data( version ); break;
-        case 7: struct TEplModel Data( version ); break;
-        case 8: struct TEplTrajectoryPolygon Data( version ); break; // TEplSoulPolygon
-        case 9: struct TEplBoardPolygon Data( version ); break;
-        case 10: struct TEplObjectParticles Data( version ); break;
-        case 11: struct TEplGlitterPolygon Data( version ); break;
-        case 12: struct TEplGlitterPolygon Data( version ); break; // TEplBrightLightPolygon
-        case 13: struct TEplDirectionalParticles Data( version ); break;
-        case 14: struct TEplCamera Data( version ); break;
-        case 15: struct TEplLight Data( version ); break;
-        case 16: struct TEplPostEffect Data( version ); break;
-        case 17: struct TEplHelper Data( version ); break;
+        case 0:  Printf("Dummy Node");          struct TEplDummy Data( version );                break;
+        case 1:  Printf("Particle");            struct TEplParticle Data( version );             break;
+        case 2:  Printf("Flash Polygon");       struct TEplFlashPolygon Data( version );         break;
+        case 3:  Printf("Circle Polygon");      struct TEplCirclePolygon Data( version );        break;
+        case 4:  Printf("Lightning Polygon");   struct TEplLightningPolygon Data( version );     break;
+        case 5:  Printf("Trajectory Polygon");  struct TEplTrajectoryPolygon Data( version );    break;
+        case 6:  Printf("Wind Polygon");        struct TEplWindPolygon Data( version );          break;
+        case 7:  Printf("Model Node");          struct TEplModel Data( version );                break;
+        case 8:  Printf("Soul Polygon");        struct TEplTrajectoryPolygon Data( version );    break; 
+        case 9:  Printf("Board Polygon");       struct TEplBoardPolygon Data( version );         break;
+        case 10: Printf("Object Emitter");      struct TEplObjectParticles Data( version );      break;
+        case 11: Printf("Glitter Polygon");     struct TEplGlitterPolygon Data( version );       break;
+        case 12: Printf("Bright Polygon");      struct TEplGlitterPolygon Data( version );       break;
+        case 13: Printf("Directional Polygon"); struct TEplDirectionalParticles Data( version ); break;
+        case 14: Printf("Camera Node");         struct TEplCamera Data( version );               break;
+        case 15: Printf("Light Node");          struct TEplLight Data( version );                break;
+        case 16: Printf("Effect Node");         struct TEplPostEffect Data( version );           break;
+        case 17: Printf("Helper Node");         struct TEplHelper Data( version );               break;
         default: Assert(false, "Not implemented"); break;
     }
 } TEplLeaf  <optimize=false>;
@@ -1410,10 +1507,10 @@ typedef struct
 typedef struct( u32 version )
 {
     SetRandomBackColor();
-
+    Printf( " *" );
     THashString FileName( version );
     u32 Field18;
-    
+
     if ( Field18 == 2 )
     {
         u32 Field00;
@@ -1430,12 +1527,8 @@ typedef struct( u32 version )
             case 5: struct TModelPackFile GmdModel; break; // GMD model, untested
             case 6: struct TEpdFile EplDisplacement; break; // EPL displacement
             default: Assert( false );
-        }  
+        }
     }
-    //else if ( Field18 != 1 )
-    //{
-    //    Assert( false );
-    //}
 } TEplEmbeddedFile <optimize=false>;
 
 typedef struct( u32 version, u32 in_type )
@@ -1444,36 +1537,39 @@ typedef struct( u32 version, u32 in_type )
 
     local u32 type = in_type;
 
-    u32 Field15C;
-    f32 Field160;
-    u32 Field164;
-    f32 Field040;
-    TVector2 Field44;
-    f32 FieldB4;
-    u32 FieldC4;
-    TVector2 FieldB8;
+    //u32 Field00 = Rotation
+    //u32 Field04 = ParticleAmount
+
+    u32 RandomSpawnDelay;
+    f32 ParticleLife; 
+    u32 AngleSeed; 
+    f32 DespawnTimer; 
+    TVector2 SpawnChoker; 
+    f32 ColorOverLifeOffset; 
+    u32 FieldC4; 
+    TVector2 OpacityOverLife; 
     
     if ( version >= 0x1104041 )
-        struct TEplLeafCommonData6 Field50;
+        struct TEplLeafCommonData6 ColorOverLife_Bezier; 
 
     if ( version >= 0x1104701 )
-        f32 FieldC0;     
+        f32 FieldC0; 
 
     if ( version < 0x1104041 )
         struct TEplLeadCommonData5 FieldC8;
     else 
-        struct TEplLeafCommonData6 FieldC8;
+        struct TEplLeafCommonData6 SizeOverLife; 
 
-    f32 Field12C;
+    f32 Field12C; //Nothing
     f32 Field130;
-    TVector2 Field134;
-    TVector2 Field13C;
-    f32 Field144;
+    TVector2 SpawnerAngles;
+    TVector2 CycleRate_FromBirth;
+    f32 CycleRate_Global;
     u32 Field148;
     u32 Field14C;
-    f32 Field150;
-    f32 Field154;
-    f32 Field158;
+    f32 Field150; 
+    f32 ParticleScale;
+    f32 ParticleSpeed;
 
     switch ( type )
     {
@@ -1488,12 +1584,12 @@ typedef struct( u32 version, u32 in_type )
     }
 } TEplParticleEmitter <optimize=false>;
 
-typedef struct 
+typedef struct
 {
     SetRandomBackColor();
 
     u16 Type;
-    
+
     switch ( Type )
     {
         case 0:
@@ -1531,12 +1627,12 @@ typedef struct
     u8 Field24[46];
 } TEplLeafCommonData5 <optimize=false>;
 
-typedef struct 
+typedef struct
 {
     SetRandomBackColor();
 
     u16 Type;
-    
+
     switch ( Type )
     {
         case 0:
@@ -1559,10 +1655,10 @@ typedef struct
 
         case 2:
         {
-            u32 Field04;
-            u32 Field0C;
-            u32 Field14;
-            u32 Field1C;
+            u8 Color1[4];
+            u8 Color2[4];
+            u8 Color3[4];
+            u8 Color4[4];
             break;
         }
 
@@ -1596,10 +1692,10 @@ typedef struct( u32 version )
 {
     SetRandomBackColor();
     TEplLeafDataHeader Header;
-    
+
     // 0(r4)
     u32 Type;
-    
+
     if ( version < 0x1104170 )
         FSeek(4);
 
@@ -1607,7 +1703,7 @@ typedef struct( u32 version )
     {
         u32 Field10;
     }
-    
+
     // 0(r27)
     struct TEplParticleEmitter Emitter( version, Type );
 
@@ -1709,7 +1805,7 @@ typedef struct( u32 version )
 typedef struct( u32 version )
 {
     struct TEplLeafCommonData5 Field88;
-    
+
     if ( version <= 0x1104040 )
         struct TEplLeafCommonData5 FieldDC;
     else
@@ -1863,7 +1959,6 @@ typedef struct( u32 version )
     u32 FieldDC;
 } TEplLightningPolygonBall;
 
-// verified
 typedef struct( u32 version )
 {
     SetRandomBackColor();
@@ -1875,15 +1970,15 @@ typedef struct( u32 version )
         FSeek( 4 );
 
     u32 Field00;
-    u32 Field04;
-    f32 Field08;
-    f32 Field0C;
-    u32 Field12C;
+    u32 Brightness;
+    f32 FuzzAmount;
+    f32 StartingSize;
+    u32 TrailLife;
     f32 Field130;
     f32 Field134;
 
     if ( version > 0x1104170 )
-        f32 Field138;
+        f32 Length;
 
     struct TEplLeafCommonData6 Field10;
     struct TEplLeafCommonData6 Field74;
@@ -1892,7 +1987,7 @@ typedef struct( u32 version )
     bool HasEmbeddedFile;
 
     if ( HasEmbeddedFile )
-        struct TEplEmbeddedFile EmbeddedFile;
+        struct TEplEmbeddedFile EmbeddedFile( version );
 
 } TEplTrajectoryPolygon;
 
@@ -1905,16 +2000,18 @@ typedef struct( u32 version )
     u32 Type;
     f32 Field00;
     f32 Field04;
-    f32 Field08;
-    f32 Field78;
+    //2 Field08;
+    byte Unknown[3];
+    u8 ParticleCount;
+    f32 WindOpacity;
     u32 Field88;
-    u32 Field8C;
-    u32 FieldA8;
+    u32 WindPolyCount;
+    u32 WindSeed;
 
     if ( version <= 0x1104040 )
-        struct TEplLeafCommonData5 Field14;
+        struct TEplLeafCommonData5 ColorOverLifeBezier;
     else
-        struct TEplLeafCommonData6 Field14;
+        struct TEplLeafCommonData6 ColorOverLifeBezier;
 
     TVector2 Field0C;
     TVector2 Field90;
@@ -1926,8 +2023,8 @@ typedef struct( u32 version )
        
     if ( version > 0x1104050 )
     {
-        f32 FieldA0;
-        f32 FieldA4;
+        f32 WindSize;
+        f32 WindSpeed;
     } 
 
     switch ( Type )
@@ -1942,12 +2039,38 @@ typedef struct( u32 version )
     struct TEplEmbeddedFile Field70( version );    
 } TEplWindPolygon;
 
+
+// verified
 // verified
 typedef struct( u32 version )
 {
-    struct TEplLeafCommonData5 FieldAC;
-    struct TEplLeafCommonData5 Field100;
-    struct TEplLeafCommonData5 Field154;
+    //struct TEplLeafCommonData5 FieldAC;  
+    u16 Type;
+    f32 NearClip;
+    f32 FarClip;
+    f32 NearTarget;
+    f32 FarTarget;
+    TVector4 Field10;
+    u8 Field24[46];
+
+    //struct TEplLeafCommonData5 Field100;
+    u16 Type;
+    f32 YRandom_Min;
+    f32 YRandom_Max;
+    f32 YWind_Top;
+    f32 YWind_Base;
+    TVector4 Field11;
+    u8 Field25[46];
+    
+    //struct TEplLeafCommonData5 Field154;
+    u16 Type;
+    f32 Phase1Height;
+    f32 Phase2Height;
+    f32 Phase3Height;
+    f32 Phase4Height;
+    TVector4 Field12;
+    u8 Field26[46];
+
     TVector2 Field1A8;
     TVector2 Field1B0;
     TVector2 Field1B8;
@@ -1964,7 +2087,7 @@ typedef struct( u32 version )
     TVector2 Field108;
     f32 Field110;
     f32 Field114;
-    
+
     if ( version > 0x1104080 )
         TVector2 Field118;
 } TEplWindPolygonExplosion;
@@ -1995,12 +2118,30 @@ typedef struct( u32 version )
         f32 Field04;
         f32 Field08;
     }
+    else
+    {
+        local f32 Field04 = 1.0f;
+        local f32 Field08 = 1.0f;
+    }
+
+    if ( Field00 & 0x10000000 )
+    {
+        f32 Field0C;
+        f32 Field10;
+        f32 Field14;
+        f32 Field18;
+        f32 Field1C;
+        f32 Field20;
+        s32 Field24;
+        f32 Field28;
+        f32 Field2C;
+    }
 
     switch ( Type )
     {
         case 0: break;
         case 1: struct TEplModel3DData Data( version ); break;
-        case 2: struct TEplModel2DData Data( version ); break; 
+        case 2: struct TEplModel2DData Data( version ); break;
         default: Assert(false, "Not implemented"); break;
     }
 
@@ -2059,8 +2200,8 @@ typedef struct( u32 version )
         TVector2 FieldF4;
 
         if ( version > 0x1104290 )
-        { 
-            f32 Field20; 
+        {
+            f32 Field20;
             f32 Field24;
         }
     }
@@ -2119,7 +2260,6 @@ typedef struct( u32 version )
     f32 Field144;
     f32 Field148;
     f32 Field14C;
-    bool Field70; // r30
 
     switch ( Type )
     {
@@ -2129,8 +2269,9 @@ typedef struct( u32 version )
         case 3: struct TEplGlitterPolygonCylinder Polygon( version ); break;
         case 4: struct TEplGlitterPolygonWall Polygon( version ); break;
         default: Assert(false, "Not implemented"); break;
-    }    
+    }
 
+    bool Field70; // r30
     if ( Field70 )
     {
         struct TEplEmbeddedFile EmbeddedFile( version );
@@ -2184,8 +2325,8 @@ typedef struct( u32 version )
     TEplLeafDataHeader Header;
 
     u32 Type;
-    
-    if ( version > 0x11084180 )
+
+    if ( version > 0x1104180 )
     {
         u32 Field00;
     }
@@ -2259,7 +2400,7 @@ typedef struct( u32 version )
 {
     SetRandomBackColor();
 
-    f32 Field170;   
+    f32 Field170;
     TVector2 Field174;
     TVector2 Field17C;
     TVector2 Field184;
@@ -2292,7 +2433,7 @@ typedef struct( u32 version )
 } TEplCamera;
 
 typedef struct( u32 version )
-{   
+{
     // empty
 } TEplCameraMeshParams;
 
@@ -2343,7 +2484,7 @@ typedef struct( u32 version )
     u32 Field18;
     u32 Field1C;
     u32 Field20;
-    
+
     if ( version > 0x1104910 )
     {
         f32 Field24;
@@ -2373,6 +2514,10 @@ typedef struct( u32 version )
         case 6: struct TEplPostEffectLensFlareData Data( version ); break;
         case 7: struct TEplPostEffectColorCorrectionData Data( version ); break;
         case 8: struct TEplPostEffectMonotoneData Data( version ); break;
+
+        case 9: struct TEplPostEffectLensFlareMake Data( version ); break;
+        case 10: struct TEplPostEffectMotionBlur Data( version ); break;
+        case 11: struct TEplPostEffectAfterimageBlur Data( version ); break;
         default: Assert(false, "Not implemented"); break;
     }
 
@@ -2390,7 +2535,7 @@ typedef struct( u32 version )
     f32 FieldDC;
     f32 FieldE0;
     f32 FieldE4;
-    
+
     if ( version > 0x1104930 )
     {
         u8 FieldE8;
@@ -2413,7 +2558,7 @@ typedef struct( u32 version )
     u32 Field74;
     TEplLeafCommonData6 Field78;
     TEplLeafCommonData6 FieldDC;
-    
+
     if ( version > 0x1104920 )
     {
         u8 Field140;
@@ -2472,6 +2617,48 @@ typedef struct( u32 version )
     TVector2 Field14;
 } TEplPostEffectMonotoneData;
 
+// verified
+typedef struct( u32 version )
+{
+    u32 Field10;
+    u32 Field20;
+    TEplLeafCommonData6 FieldA0;
+    f32 Field60;
+    f32 Field64;
+    f32 Field68;
+    f32 Field6C;
+    f32 Field70;
+    f32 Field74;
+    f32 Field78;
+    f32 Field7C;
+    f32 Field80;
+    f32 Field84;
+    f32 Field88;
+    f32 Field8C;
+    f32 Field90;
+    f32 Field94;
+    f32 Field98;
+    f32 Field9C;
+} TEplPostEffectLensFlareMake;
+
+// verified
+typedef struct( u32 version )
+{
+    TEplLeafCommonData6 Field10;
+    u32 Field74;
+    TEplLeafCommonData6 Field78;
+    f32 FieldDC;
+    f32 FieldE0;
+} TEplPostEffectMotionBlur;
+
+// verified
+typedef struct( u32 version )
+{
+    TEplLeafCommonData6 Field10;
+    u32 Field74;
+    TEplLeafCommonData6 Field78;
+    f32 FieldDC;
+} TEplPostEffectAfterimageBlur;
 
 // verified
 typedef struct( u32 version )
@@ -2483,7 +2670,7 @@ typedef struct( u32 version )
     u32 Field00;
     f32 Field04;
     f32 Field08;
-    f32 Field0C;  
+    f32 Field0C;
     bool Field84; // r30
     if ( Field84 )
         TEplEmbeddedFile EmbeddedFile1( version );
@@ -2532,7 +2719,7 @@ typedef struct( u32 version )
 		f32 Field14;
 		f32 Field10;
 	}
-	
+
 }TEntryType1<name = "Bone Dictionary">;
 
 typedef struct( u32 version )
@@ -2554,7 +2741,7 @@ typedef struct( u32 version )
 typedef struct{
 	f32 Gravity;
 	f32 Field04;
-	
+
 	f32 BoneThickness;
 	u16 parentBone;
 	u16 childBone;
@@ -2593,7 +2780,7 @@ string NameToStringT1( TEntryType1& value )
 		return buffer;
 	}
 	else buffer = "null";
-	
+
 	return buffer;
 }
 
@@ -2606,7 +2793,7 @@ string NameToStringT2( TEntryType2& value )
 		return buffer;
 	}
 	else buffer = "null";
-	
+
 	return buffer;
 }
 
@@ -2647,7 +2834,7 @@ typedef struct
     SetRandomBackColor();
 
     TFileHeader Header;
-    
+
     // Read chunks
     local u32 chunkStart;
     local u32 chunkType;
@@ -2679,7 +2866,7 @@ typedef struct
                 struct TAnimationPack AnimationPack;
                 break;
 
-			case EChunkType_PhysicsDictionary:
+            case EChunkType_PhysicsDictionary:
                 struct TPhysicsDictionary PhysicsChunkType;
                 break;
 
@@ -2712,7 +2899,7 @@ typedef struct
 
     TFileHeader Header;
     u32 Field00; // 0x00
-    
+
     if ( Field00 > 0x01010000 )
     {
         f32 FieldBC;
@@ -2728,7 +2915,7 @@ typedef struct
     u8 Field8F;
     u8 Field8E;
     u32 Field88;
-    
+
     if ( Field00 >= 0x01000001 )
     {
         f32 Field94;
@@ -2745,15 +2932,15 @@ typedef struct
     u8 FieldAE;
     f32 FieldB0;
     f32 FieldB4;
-    u32 FieldA8; 
+    u32 FieldA8;
 } TBedFile;
 
 typedef struct( u32 version )
 {
-    f32 Field1C;
-    f32 Field20;
-    f32 Field24;
-    u32 Field08;
+    f32 SkillDuration;
+    f32 RepetitionDelay;
+    f32 HitFrame;
+    u32 Dummy2;
     u32 EntryCount;
     
     if ( EntryCount > 0 )
@@ -2764,12 +2951,12 @@ typedef struct( u32 version )
 
 typedef struct( u32 version )
 {
-    f32 Field04;
-    u16 Field08;
-    u16 Field0C;
-    u16 Field10;
-    f32 Field14;
-    s32 Field18;
+    f32 Dummy3;
+    u16 Dummy4;
+    u16 Dummy5;
+    u16 Dummy6;
+    f32 Dummy7;
+    s32 Dummy8;
     TEpl Epl( version );
 } TBedList2Entry <optimize=false>;
 
@@ -2822,6 +3009,12 @@ typedef struct
     TEplLeafCommonData5 FieldAC;
     s32 Field100;
     s32 Field104;
+
+    if ( Field00 & 0x10000000 ) // flags?
+    {
+        f32 Field108;
+    }
+
     TEplEmbeddedFile EmbeddedFile1( Header.Version ); // 0x108
     TEplEmbeddedFile EmbeddedFile2( Header.Version ); // 0x10C
 } TEpdFile;
@@ -2887,7 +3080,7 @@ typedef struct
 //
 typedef struct
 {
-    
+
 } TEnvFile;
 
 //

--- a/templates/p5_path.bt
+++ b/templates/p5_path.bt
@@ -1,0 +1,25 @@
+//------------------------------------------------
+//--- 010 Editor v12.0.0 Binary Template
+// File Mask: fs***_***_***.bin,FS***_***_***.bin
+// Authors: CherryCreamSoda
+//------------------------------------------------
+#include "common/include.h"
+BigEndian();
+u32 EntryCount;
+
+typedef struct
+{
+    SetRandomBackColor();
+    float X;
+    float Y;
+    float Z;
+} PathEntry<optimize=false, read=PathRead>;
+
+string PathRead( PathEntry &h )
+{
+    local string output;
+    SPrintf( output, "X:%f    ||    Y:%f    ||    Z:%f", h.X, h.Y, h.Z);
+    return output; 
+}
+
+struct PathEntry Path[ EntryCount ];


### PR DESCRIPTION
Notable Changes:

-Added templates for PATH and CAR, two rare node based formats
-Edited GFD template with lipsum compat + DniweTamp physics chunk naming + EPL struct names + Keyframe fixes
-Completely refactored FBN for 010Editor v12.0, can run 100% of all .FBNs and parse completely.
-Appended P5R Bitflag datatype to Utils, essential for any future template updates and resources.  