### PR TITLE
Add details about Affinities, Traits, and the Technical Combo Map

### DIFF
--- a/templates/p5r_enums.bt
+++ b/templates/p5r_enums.bt
@@ -6578,6 +6578,12 @@ enum<ubyte>Skill_ApplyOrCureEffect
     ApplyMultipleEffects = 3
 };
 
+enum<ubyte>Skill_RareEffect
+{
+    NoEffect7 = 0,
+    BleedingDryBrushEff = 2
+};
+
 enum<ubyte>Skill_ExtraEffect
 {
     NoEffect6 = 0,
@@ -6587,6 +6593,7 @@ enum<ubyte>Skill_ExtraEffect
     AlwaysKills = 13, // used for 9999 damage Megidolaon (603)
     BigBangBurgerDocumentVisual = 15, // used by Shadow Okumura's Sacrifice Order
     BatonPassDamageUp = 17,
+    Pierce = 18,
     TargetedChanceUp = 19, // increases chance of being targeted by enemies
     TargetedChanceWayUp = 20, // greatly increases chance of being targeted by enemies
     IfAilmentExistsHealAndCureInstead = 21, // used for Big Bang Challenge; needs testing with other ailments

--- a/templates/p5r_enums.bt
+++ b/templates/p5r_enums.bt
@@ -6589,6 +6589,7 @@ enum<ubyte>Skill_ExtraEffect
     NoEffect6 = 0,
     OnlyHitTargetsInflictedWithFear = 1, // used by Ghastly Wail
     EscapeBattle = 2,
+	DoubleDamageIfFoeIsDown = 3, // used by Rebellion Blade
     ThrowAwayMoney = 6,
     AlwaysKills = 13, // used for 9999 damage Megidolaon (603)
     BigBangBurgerDocumentVisual = 15, // used by Shadow Okumura's Sacrifice Order
@@ -6706,6 +6707,28 @@ enum<ubyte>Skill_PassiveOrActive
     ActiveSkill = 0,
     PassiveSkill = 1, // MUST be enabled for passive skills to function properly
     NULL_Skill = 255
+};
+
+enum<int> Tech_TechnicalSkillAffinity
+{
+    TechAffinity_BLANK = -1,
+    TechAffinity_Physical = 0,
+    TechAffinity_Gun = 1,
+    TechAffinity_Fire = 2,
+    TechAffinity_Ice = 3,
+    TechAffinity_Electric = 4,
+    TechAffinity_Wind = 5,
+    TechAffinity_Psy = 6,
+    TechAffinity_Nuke = 7,
+    TechAffinity_Bless = 8,
+    TechAffinity_Curse = 9,
+    TechAffinity_Almighty = 10
+};
+
+enum<uint> Tech_RequiresKnowingTheHeart
+{
+	No = 0,
+	Yes = 0x3000013d
 };
 
 enum<int>GearEquippable

--- a/templates/p5r_structs.bt
+++ b/templates/p5r_structs.bt
@@ -51,6 +51,23 @@ typedef struct
     AffinityBitfield BrainwashAffinity <name = "Brainwash">; 
 } ElementalAffinities <name = "Elemental Affinities">;
 
+typedef struct 
+{
+  u32 OtherAilments : 20<name = "Other Ailments", comment = "Bitfield for the various 'special' ailments that players don't normally inflict">;
+  u32 AilmentStatus_11_Brainwash : 1<name = "Brainwashed">;
+  u32 AilmentStatus_10_Despair : 1<name = "Despair">;
+  u32 AilmentStatus_09_Rage : 1<name = "Rage">;
+  u32 AilmentStatus_08_Sleep : 1<name = "Sleep">;
+  u32 AilmentStatus_07_Hunger : 1<name = "Hunger">;
+  u32 AilmentStatus_06_Forget : 1<name = "Forget">;
+  u32 AilmentStatus_05_Fear : 1<name = "Fear">;
+  u32 AilmentStatus_04_Confuse : 1<name = "Confused">;
+  u32 AilmentStatus_03_Dizzy : 1<name = "Dizzy">;
+  u32 AilmentStatus_02_Shock : 1<name = "Shock">;
+  u32 AilmentStatus_01_Freeze : 1<name = "Freeze">;
+  u32 AilmentStatus_00_Burn : 1<name = "Burn">;
+} AilmentStatus;
+
 typedef struct
 {
     u8 Strength <name = "Strength">;

--- a/templates/p5r_structs.bt
+++ b/templates/p5r_structs.bt
@@ -16,22 +16,15 @@ typedef struct
 
 typedef struct
 {
-    u8 Byte2_bit32768 : 1<hidden=true>;
-    u8 Byte2_bit16384 : 1<hidden=true>;
-    u8 Ailment_Immune : 1;
-    u8 Resist : 1;
-    u8 Weak : 1;
+    u8 Double_Ailment_Chance : 1<name = "Double Ailment Chance", comment = "Used on Fire/Ice/Elec affinity to double the chance that an incoming attack inflicts the corresponding ailment (Burn/Freeze/Shock).">;
+    u8 Guarantee_Ailment : 1<name = "Guarantee Ailment", comment = "Incoming attacks with an ailment chance always inflict the ailment.">;
+    u8 Ailment_Immune : 1<name = "Ailment Immune", comment = "Incoming attacks never inflict ailments (including insta-kill). Overrides Guarantee Ailment. Does NOT prevent Critical hits.">;
+    u8 Resist : 1 <comment = "Displays Resist text and halves damage (by default) when hit. (However, If Mutliplier field is specified (non-zero), it replaces the default 0.5x multiplier.)">;
+    u8 Weak : 1 <comment = "Damage x 1.25 (by default) and knockdown. (However, if Multiplier field is specified (non-zero), it replaces the default 1.25x mutliplier.)">;
     u8 Drain : 1;
     u8 Repel : 1;
     u8 Block : 1;
-    u8 Take_640_Percent_Damage : 1;
-    u8 Take_320_Percent_Damage : 1;
-    u8 Take_160_Percent_Damage : 1;
-    u8 Take_80_Percent_Damage : 1;
-    u8 Take_40_Percent_Damage : 1;
-    u8 Take_20_Percent_Damage : 1;
-    u8 Take_10_Percent_Damage : 1;
-    u8 Take_5_Percent_Damage : 1;
+	u8 Multiplier <name = "Multiplier (in increments of 5%)", comment = "Multiplies damage & ailment chance. 20 is Neutral since 20 x 5% = 100% of normal dmg & ail. chance. 80 x 5% = 400% = 4x multiplier. 0 is ignored (does not nullify attack).">;
 } AffinityBitfield <name = "Affinity Status">;
 
 typedef struct

--- a/templates/p5r_tbl.bt
+++ b/templates/p5r_tbl.bt
@@ -78,7 +78,7 @@ typedef struct
     u8 bit13 : 1;
     u8 bit14 : 1;
     u8 bit15 : 1;
-    u8 PreventKnockdown : 1 <name = "Prevent Knockdown", comment = "Enemy can never get knockdown 100% by Critical but not WEAK">;
+    u8 NoCritical : 1 <name = "No Critical", comment = "Prevents Critical hits against enemies in this encounter.">;
     u8 PositionHack : 1 <name = "Position Hack", comment = "Triggers Position Hack when you enter the battle">;
     u8 bit18 : 1;
     u8 shadownotdisappearinbattle : 1 <name = "Not Disappear in Battle", comment = "When the shadow HP reaches 0, it will not disperse if this is turned ON in ENCOUNT.TBL Flag">;
@@ -90,7 +90,7 @@ typedef struct
     u8 bit25 : 1;
     u8 loadbattlescript : 1 <name = "Battle script load", comment = "This will load the battle script for this particular battle (CAUTION: Will cause freeze if the battle script file is not exist)">;
     u8 EnemyFirstAct : 1 <name = "Enemy First Act", comment = "This will cause all enemies to act first turn as if party got ambushed. (Whether it must be scripted or random encounter is still unknown.">;
-    u8 NoCritical : 1 <name = "No Critical", comment = "Even if you have a skill with 100% Critical, it will never trigger critical if this is ON">;
+    u8 bit28: 1;
     u8 bit29 : 1;
     u8 bit30 : 1;
     u8 NoEscape : 1 <name = "No Escape", comment = "This will make your battle unescapable if it is ON">;

--- a/templates/p5r_tbl.bt
+++ b/templates/p5r_tbl.bt
@@ -643,17 +643,13 @@ typedef struct
 
 typedef struct
 {
+    AilmentStatus ApplicableAilments<name = "Applicable Ailments", comment = "If the target has any of these ailments, the affinities in the TechnicalAffinities fields will deal Technical damage.">;
+    uint AllAffinitiesAreTechnical<name = "All Affinities are Technical", comment = "If set to 1, the TechnicalAffinities array is ignored; instead, ALL damaging skills inflict Technical damage agaisnt these ailments.">;
+    Tech_TechnicalSkillAffinity TechnicalAffinities[5]<name = "Technical Affinities", comment = "Skills of these affinities are Technical against foes with the above ailments.">;
     u32 UnknownR;
     u32 UnknownR;
-    u32 UnknownR;
-    u32 UnknownR;
-    u32 UnknownR;
-    u32 UnknownR;
-    u32 UnknownR;
-    u32 UnknownR;
-    u32 UnknownR;
-    u32 UnknownR;
-} TSkill_Skill_UnknownR <name = "Unknown Skill Segment">;
+    Tech_RequiresKnowingTheHeart RequiresKnowingTheHeart<name = "Requires Knowing the Heart", comment = "If set to Yes, this entry of the map only applies if you've read the book \"Knowing the Heart\" for extra Tech combos.">;
+} TSkill_Skill_TechnicalMap <name = "Technical Combo Map">;
 
 typedef int s32;
 
@@ -1453,7 +1449,7 @@ enum TableSegmentType
     TableSegmentType_Encounter_Segment3,
     TableSegmentType_Skill_Elements,
     TableSegmentType_Skill_ActiveSkillData,
-    TableSegmentType_Skill_Skill_UnknownR,
+    TableSegmentType_Skill_TechnicalMap,
     TableSegmentType_Skill_TraitData,
     TableSegmentType_Item_Accessories,
     TableSegmentType_Item_Armor,
@@ -1581,8 +1577,8 @@ typedef struct( TableSegmentType _type )
             TSkill_ActiveSkillData Skill[ Size / sizeof( TSkill_ActiveSkillData ) ];
             break;
 
-        case TableSegmentType_Skill_Skill_UnknownR:
-            TSkill_Skill_UnknownR Skill[ Size / sizeof( TSkill_Skill_UnknownR ) ];
+        case TableSegmentType_Skill_TechnicalMap:
+            TSkill_Skill_TechnicalMap Skill[ Size / sizeof( TSkill_Skill_TechnicalMap ) ];
             break;
 
         case TableSegmentType_Skill_TraitData:
@@ -1763,7 +1759,7 @@ typedef struct( string tableName, u32 endOffset )
             {
                 case 0: segmentType = TableSegmentType_Skill_Elements; break;
                 case 1: segmentType = TableSegmentType_Skill_ActiveSkillData; break;
-                case 2: segmentType = TableSegmentType_Skill_Skill_UnknownR; break;
+                case 2: segmentType = TableSegmentType_Skill_TechnicalMap; break;
                 case 3: segmentType = TableSegmentType_Skill_TraitData; break;
             }
         }

--- a/templates/p5r_tbl.bt
+++ b/templates/p5r_tbl.bt
@@ -646,7 +646,7 @@ typedef struct
     AilmentStatus ApplicableAilments<name = "Applicable Ailments", comment = "If the target has any of these ailments, the affinities in the TechnicalAffinities fields will deal Technical damage.">;
     uint AllAffinitiesAreTechnical<name = "All Affinities are Technical", comment = "If set to 1, the TechnicalAffinities array is ignored; instead, ALL damaging skills inflict Technical damage agaisnt these ailments.">;
     Tech_TechnicalSkillAffinity TechnicalAffinities[5]<name = "Technical Affinities", comment = "Skills of these affinities are Technical against foes with the above ailments.">;
-    u32 UnknownR;
+	float damageMultiplier <name = "Damage Multiplier", comment = "Technicals of this type will multiply damage by this amount, plus up to 0.3 for party's Techncial Rank.">;
     u32 UnknownR;
     Tech_RequiresKnowingTheHeart RequiresKnowingTheHeart<name = "Requires Knowing the Heart", comment = "If set to Yes, this entry of the map only applies if you've read the book \"Knowing the Heart\" for extra Tech combos.">;
 } TSkill_Skill_TechnicalMap <name = "Technical Combo Map">;

--- a/templates/p5r_tbl.bt
+++ b/templates/p5r_tbl.bt
@@ -78,7 +78,7 @@ typedef struct
     u8 bit13 : 1;
     u8 bit14 : 1;
     u8 bit15 : 1;
-    u8 NoCritical : 1 <name = "No Critical", comment = "Prevents Critical hits against enemies in this encounter.">;
+    u8 PreventKnockdown : 1 <name = "Prevent Knockdown", comment = "Enemy can never get knockdown 100% by Critical but not WEAK">;
     u8 PositionHack : 1 <name = "Position Hack", comment = "Triggers Position Hack when you enter the battle">;
     u8 bit18 : 1;
     u8 shadownotdisappearinbattle : 1 <name = "Not Disappear in Battle", comment = "When the shadow HP reaches 0, it will not disperse if this is turned ON in ENCOUNT.TBL Flag">;
@@ -90,7 +90,7 @@ typedef struct
     u8 bit25 : 1;
     u8 loadbattlescript : 1 <name = "Battle script load", comment = "This will load the battle script for this particular battle (CAUTION: Will cause freeze if the battle script file is not exist)">;
     u8 EnemyFirstAct : 1 <name = "Enemy First Act", comment = "This will cause all enemies to act first turn as if party got ambushed. (Whether it must be scripted or random encounter is still unknown.">;
-    u8 bit28: 1;
+    u8 NoCritical : 1 <name = "No Critical", comment = "Even if you have a skill with 100% Critical, it will never trigger critical if this is ON">;
     u8 bit29 : 1;
     u8 bit30 : 1;
     u8 NoEscape : 1 <name = "No Escape", comment = "This will make your battle unescapable if it is ON">;

--- a/templates/p5r_tbl.bt
+++ b/templates/p5r_tbl.bt
@@ -634,8 +634,8 @@ typedef struct
     u8 UnknownR;
     u8 UnknownR;
     u8 UnknownR;
-    u8 UnknownR;
-    Skill_ExtraEffect ExtraEffect <name = "Extra Effects", comment = "Ignore resistance works 100% for Physical. Magic including Light, Dark, Almighty can only Semi Pierce (NULL, DRAIN, REPEL can't be pierced).">;
+    Skill_RareEffect RareEffect <name = "Rare Effect", comment = "This byte is only ever set for Bleeding Dry Brush. Value of 2 applies one-use Drain All Affinities (except Almighty) barrier on target.">;
+    Skill_ExtraEffect ExtraEffect <name = "Extra Effects", comment = "Pierce works 100% for Physical. Magic including Light, Dark, Almighty can only Semi Pierce (NULL, DRAIN, REPEL can't be pierced).">;
     u8 CritChance <name = "Crit Chance", comment = "Only works for Physical or Gun skills">;
     u8 Unknown <name = "Unknown">;
     u8 Unknown <name = "Unknown">;
@@ -659,24 +659,21 @@ typedef int s32;
 
 typedef struct
 {
-  u16 ord; // trait command
+  u16 ord <name = "Effect", comment = "Selects the effect of the trait from a preprogrammed list.">;
   u16 field_2;
-  s32 effect_rate;
+  s32 effect_rate <name = "Effect Rate", comment = "Percent chance that the trait triggers.">;
   
-  union {
-    s32 trait; // sub trait
-    s32 trait_effects; // bitfield
-  } effect;
+  s32 union_effect <name = "Sub Trait", comment = "Adds effect of trait with given ID to this trait. Requires 'Use Sub Trait'=1.">;
 
-  f32 effect_size;
-  s32 trait_ex[ 10 ]; // extra inheritable traits in fusion
+  f32 effect_size <name = "Effect Size", comment = "Strength of effect. Usually a multiplier for damage, healing, skill costs, ailment chance, etc.">;
+  s32 trait_ex[ 10 ] <name = "Substitute Traits", comment = "Alternate inheritable traits during fusion if this one is a duplicate or a Treasure Demon trait.">;
 
   struct
   {
-    s32 IsUnique : 1;
-    s32 IsTreasure : 1;
-    s32 HasSubTrait : 1; // see effect union
-    s32 _ : 29 <name = "Inheritable Trait", comment="Put 0 for inheritable trait. Put 1 if you don't want to">;
+	s32 UnknownBitfield : 29;
+	s32 UseSubTrait : 1 <name = "Use Sub Trait", comment = "If set to 1, this trait will also include effects of trait with ID in the 'Sub Trait' field.">;
+	s32 IsTreasure : 1 <name = "Is Treasure", comment = "If 1, indicates that this is from a Treasure Demon and a substitute trait should be inherited instead.">;
+    s32 IsUnique : 1 <name = "Is Unique", comment = "Put 0 for inheritable trait. Put 1 if you don't want to">;
   } trait_flags;
 } TSkill_TraitData;
 


### PR DESCRIPTION
- Adds template comments about affinities' effects on damage and ailment chances
- Adds the missing names and explanations for the first 2 bits of affinity bitmap (determined through experimentation)
- Explains the affinity multiplier field (second byte) and condenses it into a single byte (instead of bitflags) to improve readability of the total value
- Add details to the Trait section of SKILL.TBL
- Change the unknown section of SKILL.TBL to "Technical Map" because it is used to determine which skill affinities cause Technical damage against which ailments

For experimental evidence supporting the changes about affinities, see this Google Sheet listing my attempts at inflicting Freeze and damage against different Ice affinity values:  https://docs.google.com/spreadsheets/d/17jJeViX5Tv-aWT6x4OUQNOZEiMBT7SPHyh9chA6iZG0/edit?usp=sharing

NOTE: this PR originally contained a change to ENCOUNT.TBL as well to address flags about Crittability of enemy encounters, but someone pointed out that the Reaper cannot be Critted even though it has none of the known flags setting that, so we need to research further.