### PR TITLE
Templates for Metaphor: Refantazio

### DIFF
--- a/templates/gfd_env.bt
+++ b/templates/gfd_env.bt
@@ -1,0 +1,716 @@
+//------------------------------------------------
+//--- 010 Editor v12.0 Binary Template
+//
+//      File: gfd_env.bt
+//   Authors: Rirurin (based on p5_env by TGE, Cherry, Sierra, SecreC)
+//   Version: 1.0
+//   Purpose: Parse Persona 5 / Metaphor: Refantazio ENV files
+//  Category: GFD
+// File Mask: *.env
+//  ID Bytes:
+//   History:
+//------------------------------------------------
+
+typedef char bool;
+typedef char s8;
+typedef uchar u8;
+typedef int16 s16;
+typedef uint16 u16;
+typedef int16 s16;
+typedef int32 s32;
+typedef uint32 u32;
+typedef int64 s64;
+typedef uint64 u64;
+typedef hfloat f16;
+typedef float f32;
+typedef double f64;
+
+local f32 ColorExp = 2.2;
+
+enum<u8> Boolean
+{
+    False = false,
+    True = true,
+};
+
+string GetBooleanString(Boolean value) {
+    string buffer;
+    if (value == False) {
+        SPrintf(buffer, "False");
+    } else {
+        SPrintf(buffer, "True");
+    }
+    return buffer;
+}
+
+local uint __RandomSeed = 0xDEADBABE;
+local uint __RandomBit = 0;
+local uint __RandomCount = 0;
+
+uint MyRandom(uint to)
+{
+    ++__RandomCount;
+    __RandomBit = ((__RandomSeed >> 0) ^ (__RandomSeed >> 2) ^ (__RandomSeed >> 3) ^ (__RandomSeed >> 5)) & 1;
+    __RandomSeed = ((((__RandomBit << 15) | (__RandomSeed >> 1)) + (0xBABE / __RandomCount)) % to);
+
+    while (__RandomSeed < 0)
+        __RandomSeed += to;
+
+    return __RandomSeed;
+}
+
+typedef struct {
+    f32 x;
+    f32 y;
+    f32 z;
+} Vector3 <read=(Str("vec3(%g, %g, %g)", x, y, z))>;
+
+typedef struct {
+    u8 r;
+    u8 g;
+    u8 b;
+    u8 a;
+} ByteColorRGBA<read=(Str("#%.2x%.2x%.2x%.2x", r, g, b, a))>;
+
+typedef struct {
+    f32 r;
+    f32 g;
+    f32 b;
+} FloatColorRGB <read=(Str("#%.2x%.2x%.2x", r * 255, g * 255, b * 255))>;
+
+string ReadFloatColorRGBA(struct FloatColorRGBA& self) {
+    string buffer;
+    SPrintf(buffer, "#%.2x%.2x%.2x%.2x <%g, %g, %g, %g>", 
+        self.r * 255, self.g * 255,self. b * 255, self.a * 255,
+        Pow(self.r, ColorExp), Pow(self.g, ColorExp), Pow(self.b, ColorExp), Pow(self.a, ColorExp)
+    );
+    return buffer;
+}
+
+typedef struct {
+    f32 r;
+    f32 g;
+    f32 b;
+    f32 a;
+} FloatColorRGBA <read=ReadFloatColorRGBA>;
+
+local uint sHashTable[256] =
+{
+  0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
+  0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91,
+  0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7,
+  0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5,
+  0x3B6E20C8, 0x4C69105E, 0xD56041E4, 0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B,
+  0x35B5A8FA, 0x42B2986C, 0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59,
+  0x26D930AC, 0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
+  0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D,
+  0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433,
+  0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, 0x91646C97, 0xE6635C01,
+  0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457,
+  0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65,
+  0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB,
+  0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
+  0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
+  0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, 0xB7BD5C3B, 0xC0BA6CAD,
+  0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683,
+  0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1,
+  0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7,
+  0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5,
+  0xD6D6A3E8, 0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
+  0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF, 0x4669BE79,
+  0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F,
+  0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D,
+  0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A, 0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713,
+  0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21,
+  0x86D3D2D4, 0xF1D4E242, 0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777,
+  0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
+  0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB,
+  0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
+  0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693, 0x54DE5729, 0x23D967BF,
+  0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D
+};
+
+uint BitwiseRotateLeft( uint x, int amount )
+{
+  return ( x << amount ) | ( x >> ( ( 32 - amount ) & 31 ) );
+}
+
+int GenerateStringHash( char value[] )
+{
+  local uint len = Strlen( value );
+
+  if ( !len )
+    return 0;
+
+  local uint hash = len;
+
+  local int i;
+  local uint tableIdx;
+
+  for ( i = 0; i < len; i++ )
+  {
+    tableIdx = hash ^ ( byte )( value[i] );
+    tableIdx = ( BitwiseRotateLeft( tableIdx, 2 ) & 0x000003FC ) / sizeof( uint );
+    hash = BitwiseRotateLeft( hash, 24 ) & 0x00FFFFFF;
+    hash ^= sHashTable[tableIdx];
+  }
+
+  return ( int )hash;
+}
+
+string THashStringToString( struct THashString& value )
+{
+    if ( value.Length == 0 )
+        return "<empty string>";
+
+    string buffer;
+    SPrintf( buffer, "%s (%08X) [%08X]", value.Str, value.Hash, GenerateStringHash( value.Str ) );
+
+    return buffer;
+}
+
+typedef struct
+{
+  SetBackColor(MyRandom(0xFFFFFFFF));
+  u16 Length;
+
+  if ( Length )
+  {
+    char Str[Length];
+
+    if ( header.Version > 0x01080000 )
+    {
+      u32 Hash;
+    }
+  }
+} THashString <optimize=false, read=THashStringToString>;
+
+typedef struct
+{
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    char Magic[4];
+    u32 Version<format = hex, name = "GFS Version">;
+    Printf("\nVersion Number: %Lx\n", Version);
+    u32 FileType<name = "File Type">;
+    u32 Field0C;
+
+} Header<read=Str("%s, ver 0x%x", Magic, Version)>;
+
+string ReadGfdEnvironmentLight(struct GfdEnvironmentLightBase& self) {
+    string buffer;
+    SPrintf(buffer, "light type %d: amb %s, diff %s, spec %s", self.type, ReadFloatColorRGBA(self.ambient), ReadFloatColorRGBA(self.diffuse), ReadFloatColorRGBA(self.specular));
+    return buffer;
+}
+
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean active<name="Is Active?">;
+    u8 type<name="Light Type">;
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    FloatColorRGBA ambient<name="Ambient Color">;
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    FloatColorRGBA diffuse<name="Diffuse Color">;
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    FloatColorRGBA specular<name="Specular Color">;
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    f32 kC;
+    f32 kL;
+    f32 kQ;
+    f32 theta;
+    f32 phi;
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Vector3 position<name="Light Position">;
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Vector3 rotation<name="Light Rotation">;
+    
+} GfdEnvironmentLightBase<read=ReadGfdEnvironmentLight>;
+
+typedef struct {
+    GfdEnvironmentLightBase data;
+    if (header.Version >= 0x2098001) {
+        f32 MetaphorField0;
+        if (header.Version >= 0x2104001) {
+            f32 MetaphorField1;
+        }
+    }
+} GfdEnvironmentLightField<read=ReadGfdEnvironmentLight(data)>;
+typedef struct {
+    GfdEnvironmentLightBase data;
+    if (header.Version >= 0x2098001) {
+        f32 MetaphorField0;
+    }
+} GfdEnvironmentLightIndependence<read=ReadGfdEnvironmentLight(data)>;
+
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    f32 fovy;
+    f32 nearClip;
+    f32 farClip;
+} GfdEnvironmentCamera;
+
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled;
+    f32 Field200;
+    f32 Field204<name="fogParametersR">;
+    f32 Field208<name="fogParametersG", read=Str("%g -> %g", this, (50-this)*0.0001)>;
+    f32 Field20c<name="fogColorParameterA">;
+    f32 Field210<name="fogParametersA", read=Str("%d -> %d", this, this*0.001*200000)>;
+    f32 Field214;
+    f32 Field218<name="fogColorR">;
+    f32 Field21c<name="fogColorG">;
+    f32 Field220<name="fogColorB">;
+    f32 Field228<name="dirInscatColorA">;
+    f32 Field22c<name="dirInscatStartDistance", read=Str("%g -> %g", this, this*200000)>;
+    f32 Field230<name="dirInscatColorR">;
+    f32 Field234<name="dirInscatColorG">;
+    f32 Field238<name="dirInscatColorB">;
+    if (header.Version >= 0x2101001) {
+        f32 Field224<name="fogColorMultiplyFactor">;
+        f32 Field23c<name="dirInscatMultiplyFactor">;
+        if (header.Version >= 0x2110111) {
+            f32 Field258<name="fogColorParameter_skyR">;
+            f32 Field25c<name="fogColorParameter_skyG">;
+            f32 Field260<name="fogColorParameter_skyB">;
+            f32 Field264<name="fogColorParameter_skyMultiplyFactor">;
+            f32 Field24c<name="fogColorParameter_skyA">;
+            if (header.Version >= 0x2110175) {
+                f32 Field280;
+                f32 Field284;
+                f32 Field288;
+                f32 Field28c;
+                f32 Field290;
+                u8 Field294;
+            }
+        }    
+    }
+} MetaphorSection1<read=Str("Enabled: %s", GetBooleanString(Enabled))>;
+
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Active;
+    f32 end;
+    f32 start;
+    FloatColorRGBA color<name="Height Fog Color">;
+} GfdEnvironmentHeightFog;
+
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    if (header.Version >= 0x2110188) {
+        f32 Field240;
+        f32 Field244;
+        f32 Field248;
+        f32 Field250;
+        f32 Field254;
+        f32 Field268;
+        f32 Field26c;
+        f32 Field270;
+        f32 Field274;
+        f32 Field278;
+        f32 Field27c;
+    }
+    Boolean Active;
+    if (header.Version >= 0x2110219) {
+        Boolean Field298;
+    }
+    if (header.Version > 0x1102000) {
+        u16 Mode;
+    }
+    Boolean CameraClip;
+    f32 NearClip;
+    f32 FarClip;
+    FloatColorRGBA color<name="Fog Color">;
+    if (header.Version >= 0x2110194) {
+        f32 Field2BC;
+        f32 Field2C0;
+        FloatColorRGBA Field2C4;
+    }
+    if (header.Version >= 0x2110175) {
+        FloatColorRGBA Field2D4;
+        u8 Field2E4;
+    }
+    if (header.Version > 0x1104020) {
+        GfdEnvironmentHeightFog heightFog<name="Height Fog">;
+    }
+    if (header.Version >= 0x2110174) {
+        f32 Field304;
+        f32 Field308;
+    }
+    if (header.Version > 0x2110120) {
+        FloatColorRGBA Field30C<name="fogHeightColor_sky">;
+    }
+    if (header.Version >= 0x2110175) {
+        FloatColorRGBA Field31C;
+        u8 Field32C;
+    }
+} GfdEnvironmentFog;
+
+typedef struct {
+    Boolean ToneMap;
+    Boolean StarFilter;
+    Boolean AdaptedLumAuto;
+    f32 middleGray;
+    f32 bloomScale;
+    f32 starScale;
+    f32 adaptedLum;
+    f32 elapsedTime;
+    if (header.Version >= 0x1104301) {
+        f32 starLength;
+        f32 starGlareCA;
+        f32 starGlareSI;
+        u32 starNumLines;
+    }
+    if (header.Version >= 0x1105041) {
+        if (header.Version < 0x1105051) {
+            u8 P5RField0;
+            u32 P5RField1;
+            u32 P5RField2;
+            u32 P5RField3;
+        } else {
+            u8 Field337;
+            f32 Field35C;
+            f32 Field360;
+            if (header.Version >= 0x2109401) {
+                f32 Field36C;
+            }
+            if (header.Version >= 0x2110181) f32 Field368;
+            if (header.Version >= 0x2110197) f32 Field370;
+            if (header.Version >= 0x2110201) f32 Field374;
+            if (header.Version >= 0x2110202) {
+                f32 Field378;
+                u8 Field37C;
+                f32 Field380;
+            }
+            if (header.Version >= 0x2110171) {
+                f32 Field384;
+                f32 Unk;
+            }
+        }
+    }
+} GfdDeviceHDRParams<read=Str("Tone Map: %s, Star Filter: %s, Adapted Lum Auto: %s", GetBooleanString(ToneMap), GetBooleanString(StarFilter), GetBooleanString(AdaptedLumAuto))>;
+
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean active;
+    GfdDeviceHDRParams params;
+} GfdEnvironmentHDR<read=Str("Enabled: %s", GetBooleanString(active))>;
+
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled;
+    f32 FilmSlope;
+    f32 FilmToe;
+    f32 FilmShoulder;
+    f32 FilmBlackClip;
+    f32 FilmWhiteClip;
+    if (header.Version > 0x2103000) {
+        f32 FilmAlpha;
+    }
+} MetaphorSection2<read=Str("Enabled: %s", GetBooleanString(Enabled))>;
+
+// TODO
+typedef struct {
+    f32 focalPlane;
+    f32 NearBlurPlane;
+    f32 FarBlurPlane;
+    f32 FarBlurLimit;
+    f32 BlurScale;
+    if (header.Version < 0x2099001) {
+        if (header.Version > 0x1105000) {
+            u32 GaussType;
+        }
+    } else {
+        f32 Field3BC;
+        f32 Field3C0;
+        u32 GaussType;    
+    }
+    
+} gfdDeviceDOFParams;
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled;
+    if (header.Version > 0x2110219) {
+        u8 Field3C9;
+    }
+    f32 Field3E0;
+    f32 Field3E4;
+    f32 Field3E8;
+    f32 Field3EC;
+    if (header.Version < 0x2110187) {
+        f32 Unk0;
+        f32 Unk1;
+    } else {
+        FloatColorRGBA Field3F0<name="Composite Color">;
+    }
+} MetaphorSection11<read=Str("Enabled: %s", GetBooleanString(Enabled))>;
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled;
+    u32 Field404;
+    f32 Field408<name="Shadow Far Clip (shadowSplit.b)">;
+    if (header.Version > 0x2110220) {
+        f32 Field40C;
+    }
+    f32 Field410;
+    f32 Field414;
+    f32 Field418;
+    f32 Field41c;
+    f32 Field420;
+    f32 Field424;
+    f32 Field428;
+    if (header.Version >= 0x2050011 ) {
+        FloatColorRGBA Field42C;
+    }
+} MetaphorSection12<read=Str("Enabled: %s", GetBooleanString(Enabled))>;
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled_All;
+    f32 Field440<name="Screen Red/Cyan">;
+    f32 Field444<name="Screen Green/Magenta">;
+    f32 Field448<name="Screen Blue/Yellow">;
+    f32 Field44c<name="Screen Dodge">;
+    if (header.Version >= 0x1104141) {
+        f32 Field450<name="Screen Burn">;
+        if (header.Version >= 0x2000005) {
+            f32 Field454<name="Screen Hue">;
+            f32 Field458<name="Screen Saturation">;
+            f32 Field45c<name="Screen Lightness">;
+        }
+    }
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    if (header.Version < 0x2000002) {
+        FSeek(FTell() + 0x10);
+    } else if (header.Version >= 0x2092001) {
+        Boolean Enabled_Exct;
+        f32 Field464<name="Field Red/Cyan">;
+        f32 Field468<name="Field Green/Magenta">;
+        f32 Field46c<name="Field Blue/Yellow">;
+        f32 Field470<name="Field Dodge">;
+        f32 Field474<name="Field Burn">;
+        f32 Field478<name="Field Hue">;
+        f32 Field47c<name="Field Saturation">;
+        f32 Field480<name="Field Lightness">;
+    }
+} MetaphorSection10<read=Str("Screen: %s, Field: %s", GetBooleanString(Enabled_All), GetBooleanString(Enabled_Exct))>;
+
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean active;
+    gfdDeviceDOFParams params;
+} GfdEnvironmentDOF<read=Str("Enabled: %s", GetBooleanString(active))>;
+
+// TODO
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled;
+    f32 Field488;
+    if (header.Version >= 0x1104091) {
+        f32 Field48C;
+    }
+    if (header.Version >= 0x1104961) {
+        f32 Field490;
+    }
+    if (header.Version >= 0x1105021) {
+        f32 Field494;
+        f32 Field498;
+    }
+    if (header.Version >= 0x2093001) {
+        f32 Field49C;
+        f32 Field4A0;
+        f32 Field4A4;
+    }
+    if (header.Version >= 0x2110207) {
+        u8 Field4A8;
+        f32 Field4AC;
+    }
+} MetaphorSection4<read=Str("Enabled: %s", GetBooleanString(Enabled))>;
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Active;
+    Vector3 Direction;
+    f32 MinPower;
+    f32 MaxPower;
+    f32 MinCycle;
+    f32 MaxCycle;
+} GfdEnvironmentWind;
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Active;
+    f32 Gravity;
+    if (header.Version >= 0x1104121) {
+        GfdEnvironmentWind Wind;
+    }
+    if (header.Version >= 0x2109201) {
+        u32 Field4d8;
+        u8 Field4dc;
+        f32 Field4e0;
+    }
+} GfdEnvironmentPhysics<read=Str("Enabled: %s", GetBooleanString(Active))>;
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled;
+    if (header.Version < 0x2109801) {
+        f32 Unk0;
+    } else {
+        f32 WobbFocalPlane;
+        f32 WobbNearRange;
+        f32 WobbFarRange;
+        f32 WobbFarBlurLimit;
+    }
+    if (header.Version >= 0x2020001) {
+        f32 WobbPower<read=Str("%g -> %g", this, this*0.0001)>;
+    }
+    if (header.Version < 0x2109801) {
+        f32 Unk0;
+    } else {
+        f32 EdgeFocalPlane;
+        f32 EdgeNearRange;
+        f32 EdgeFarRange;
+        f32 EdgeFarBlurLimit;
+    }
+    if (header.Version >= 0x2020001) {
+        f32 EdgeSize;
+        f32 EdgePower;
+    }
+    if (header.Version >= 0x2050011) {
+        f32 WobbScale<read=Str("%g -> %g", this, (1-this)*0.001)>;
+        if (header.Version >= 0x2100001) {
+            f32 EdgeLimit<read=Str("%g -> %g", this, this*0.01)>;
+        }
+        if (header.Version >= 0x2109301) {
+            f32 Field51C<name="EdgeColorR", read=Str("%g -> %g", this, Pow(this, ColorExp))>;
+            f32 Field520<name="EdgeColorG", read=Str("%g -> %g", this, Pow(this, ColorExp))>;
+            f32 Field524<name="EdgeColorB", read=Str("%g -> %g", this, Pow(this, ColorExp))>;
+        }
+        if (header.Version >= 0x2110081) {
+            f32 edgesize_sky;
+            f32 edgepower_sky;
+            f32 edgelimit_sky;
+        }
+    }
+} GfdEnvironmentTemperare<read=Str("Enabled: %s", GetBooleanString(Enabled))>;
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled;
+    f32 Field538<name="Global Density">;
+    f32 Field53c<name="Phase">;
+    f32 Field540<name="Coverage">;
+    f32 Field544<name="Type">;
+    f32 Field548<name="Wetness">;
+    f32 Field54c<name="WindSpeed">;
+    f32 Field550<name="WindAngle">;
+    f32 Field554<name="GodrayWeight">;
+    f32 Field558<name="GodrayDensity">;
+    f32 Field55c<name="GodrayDecay">;
+    f32 Field560<name="SunDiskScale">;
+    f32 Field564<name="SunLuminance">;
+    f32 Field568<name="ResolutionDiv">;
+    s32 Field56c<name="StepMaxNum">;
+    if (header.Version >= 0x2110011) {
+        FloatColorRGBA CloudColor;
+    }
+} MetaphorSection8<read=Str("Enabled: %s", GetBooleanString(Enabled))>;
+// TODO
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled;
+    f32 Field584<name="Weight">;
+    f32 Field588;
+} MetaphorSection5<read=Str("Enabled: %s", GetBooleanString(Enabled))>;
+// TODO
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    Boolean Enabled;
+    f32 Field594<name="Water Animated Speed", read=Str("%g ->  %g", this, this*0.01)>;
+    f32 Field598;
+    f32 Field59c<name="Wave Scale">;
+    f32 Field5a0<name="TC Scale">;
+    f32 Field5a4<name="Ocean Depth Scale">;
+    f32 Field5a8<name="Disturbance Camera Scale">;
+    f32 Field5ac<name="Disturbance Depth Scale">;
+    f32 Field5b0<name="Scattering Camera Scale">;
+    f32 Field5b4<name="Disturbance Tolerance">;
+    f32 Field5b8<name="Foam Tolerance">;
+    f32 Field5bc<name="Caustics Tolerance">;
+    Boolean Field5c0;
+    Boolean Field5c1;
+} MetaphorSection6<read=Str("Enabled: %s", GetBooleanString(Enabled))>;
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    FloatColorRGB Field5d0<name="Scene Ambient PBR">;
+    f32 Field5DC;
+    //FloatColorRGBA Field5e0<name="Color 2">;
+    f32 Field5E0;
+    f32 Field5E4;
+    f32 Field5E8<name="ENV_COLORS.sceneAmbientToon.B", read=Str("%g -> %g", this, Pow(this, ColorExp))>;
+    f32 Field5EC<name="ENV_COLORS.sceneToonShadowAlpha", read=Str("%g -> %g", this, Pow(this, ColorExp))>;
+} MetaphorSection9;
+
+// TODO
+typedef struct {
+    SetBackColor(MyRandom(0xFFFFFFFF));
+    FloatColorRGBA Field5F0<name="Scene Ambient Sky">;
+    f32 Field6C8;
+    FloatColorRGBA Field600<name="Scene Sky Color">; // * 3 (Brilehaven ENV)
+    FloatColorRGBA Field610<name="Scene ENV Color">;
+    FloatColorRGBA Field620<name="Scene ENV Color Toon">;
+    f32 Field630;
+    f32 Field634;
+    FloatColorRGBA Field638<name="Water Deep Color (No Skybox Influence)">;
+    FloatColorRGBA Field648<name="Water Scatter Color (No Skybox Influence)">;
+    FloatColorRGBA Field658<name="Water Reflection Color (No Skybox Influence)">;
+    FloatColorRGBA Field668<name="Water Foam Color (No Skybox Influence)">;
+    FloatColorRGBA Field678<name="Water Deep Color (Skybox Influenced)">;
+    FloatColorRGBA Field688<name="Water Deep Color (Skybox Influenced)">;
+    FloatColorRGBA Field698<name="Water Deep Color (Skybox Influenced)">;
+    FloatColorRGBA Field6A8<name="Water Deep Color (Skybox Influenced)">;
+    FloatColorRGBA Field6B8<name="Scene Sky Fog Color">;
+    u32 Field6CC;
+    THashString HDRFilename;
+    THashString IBLFilename;
+    THashString LUTFilename;
+    THashString EnvToonFilename;
+    Boolean Field789<name="Has Skybox Mesh">;
+    THashString SkyboxObject;
+    f32 Field784<name="Skybox Y Offset">;
+    Boolean Field788<name="Unknown Skybox Flag">;
+    f32 Field758;
+    f32 Field75C;
+
+} MetaphorSection7;
+
+if (ReadUInt() == 0x30534647) 
+{
+    BigEndian();
+}
+Header header<name = "ENV Header">;
+GfdEnvironmentLightField lights[3]<name="Field Lights">;
+GfdEnvironmentLightIndependence independenceLight<name="Character Light">;
+GfdEnvironmentCamera camera<name="Camera Settings">;
+if (header.Version >= 0x2020000)
+    MetaphorSection1 metaphorSection1<name="Fog Parameters 1 (GFD_PSCONST_FOG)">;
+GfdEnvironmentFog fog<name="Fog Parameters 2 (GFD_PSCONST_FOG)">;
+GfdEnvironmentHDR hdr<name="HDR (GFD_PSCONST_HDR)">;
+if (header.Version >= 0x2102001)
+    MetaphorSection2 section2<name="Tone Map (GFD_PSCONST_TONEMAP)">;
+GfdEnvironmentDOF dof<name="Depth of Field (GFD_PSCONST_DOF)">;
+if (header.Version >= 0x2099001)
+    MetaphorSection11 section11<name="SSAO (GFD_PSCONST_SSAO)">;
+MetaphorSection12 section12<name="Shadow? (GFD_PSCONST_SHADOW)">;
+MetaphorSection10 section10<name="Color Correction (GFD_PSCONST_CORRECT)">;
+MetaphorSection4 section4;
+GfdEnvironmentPhysics physics<name="Physics">;
+if (header.Version >= 0x2020001)
+    GfdEnvironmentTemperare temperare<name="Temperare (GFD_PSCONST_TEMPERARE)">;
+if (header.Version > 0x205ffff )
+    MetaphorSection8 section8<name="Clouds (GFD_PSCONST_CLOUDS)">;
+if (header.Version >= 0x2110173)
+    MetaphorSection5 section5<name="LUT Recolor Weighting (GFD_PSCONST_LUT)">;
+if (header.Version >= 0x2110205)
+    MetaphorSection6 section6<name="Infinite Ocean (gfdInfiniteOcean.gfs)">;
+if (header.Version >= 0x2110205)
+    MetaphorSection9 section9<name="LUT Recolor Parameters">;
+if (header.Version >= 0x2110185)
+    MetaphorSection7 section7<name="Environment Colors">;
+u32 EOF<hidden=true>;
+Assert(EOF == 0x12 || EOF == 0x52, "End of file got unexpected value. Should be 0x12");

--- a/templates/metaphor_evt_ecs.bt
+++ b/templates/metaphor_evt_ecs.bt
@@ -1,0 +1,190 @@
+//------------------------------------------------
+//--- 010 Editor v12.0.1 Binary Template
+//
+//      File: metpahor_evt_ecs.bt
+//   Authors: Rirurin (based on p5_evt_ecs.bt by TGE)
+//   Version: 1.0
+//   Purpose: Parse Metaphor: Refantazio evt & ecs files
+//  Category: GFD
+// File Mask: *.evt, *.ecs
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#include "common/include.h"
+
+// Math types
+typedef struct
+{
+    f32 X;
+    f32 Y;
+    f32 Z;
+} Vector3 <read=ReadVector3, write=WriteVector3>;
+
+string ReadVector3( Vector3& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f, %.6f]", value.X, value.Y, value.Z );
+
+    return buffer;
+}
+
+void WriteVector3( Vector3& value, string s )
+{
+    SScanf( s, "[%f, %f, %f]", value.X, value.Y, value.Z );
+}
+
+typedef struct
+{
+    f32 X;
+    f32 Y;
+    f32 Z;
+    f32 W;
+} Quaternion <read=ReadQuaternion, write=WriteQuaternion>;
+
+string ReadQuaternion( Quaternion& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f, %.6f, %.6f]", value.X, value.Y, value.Z, value.W );
+
+    return buffer;
+}
+
+void WriteQuaternion( Quaternion& value, string s )
+{
+    SScanf( s, "[%f, %f, %f, %f]", value.X, value.Y, value.Z, value.W );
+}
+
+// Field Scene
+// Indicates which field object should be loaded as the current scene.
+typedef struct
+{
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+    u32 Field10;
+    u32 Field14;
+    f32 Field18;
+    u32 Field1C;
+    u32 Field20;
+    u32 Field24;
+    u32 Field28;
+    u32 Field2C;
+    u32 Field30;
+    u32 Field34;
+    u32 Field38;
+    u32 Field3C;
+
+} CommandData_FS;
+
+typedef struct {
+    SetRandomBackColor();
+    char Magic[3];
+    u8 SwapEndian<hidden=true>;
+    u32 Version<format=hex>;
+    u16 Field08;
+    u16 Field0A;
+    u8 Field0C;
+    u8 FIeld0D;
+    u8 Field0E;
+    u8 Field0F;
+    u32 Field10;
+    u32 Field14;
+    u32 Field18;
+    s32 Field1C;
+    u8 Field20;
+    u8 Field21;
+    u16 Field22;
+    u16 Field24;
+    u16 Field26;
+    u32 Field28;
+    u32 Field2C;
+    u32 FirstSectionCount;
+    u32 HeaderSize;
+    u32 FirstSectionEntrySize;
+    u32 Field3C;
+    u32 Field40;
+    u32 Field44;
+    u32 Field48;
+    u32 Field4C;
+    u32 Field50;
+    u32 Field54;
+    u32 Field58;
+    u32 Field5C;
+    u32 Field60;
+    u32 Field64;
+    u32 Field68;
+    u32 Field6C;
+    u32 Field70[8];
+    u8 Field90[0x40];
+    s32 FieldD0;
+    s32 FieldD4;
+    s32 FieldD8;
+    s32 FieldDC;
+    s32 FieldE0;
+} EvtHeader<read=Str("Version 0x%X", Version)>;
+
+typedef struct(EvtHeader& header) {
+    u32 Field00;
+    u32 Field04;
+    u32 majorId;
+    u32 minorId;
+    u32 subId0;
+    u32 subId1;
+    char Filename[0x100];
+} EvtObjectFile<read=Filename>;
+
+typedef struct(EvtHeader& header) {
+    SetRandomBackColor();
+    u32 ObjectId;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+    u32 MajorId;
+    u16 Field14;
+    u16 Field16;
+    u32 Field18;
+    u32 Field1C;
+    
+    u32 Field20;
+    EvtObjectFile Field24(header);
+    EvtObjectFile Field13C(header);
+    EvtObjectFile Field254(header);
+    EvtObjectFile Field36C(header);
+    u32 Field484;
+    u32 Field488;
+    u32 Field48C;
+    u8 Field490[0x40];
+    u8 Field4D0[0x40];
+} EvtObjects<optimize=false, read=Str("ID %d", ObjectId)>;
+
+typedef struct {
+    SetRandomBackColor();
+    char Cmd[0x4];
+    u16 Field04;        // 0, 1, 2 usually
+    u16 Field06;        // always 0?
+    u32 ObjectId;       // reference to event object
+    u32 Field0C;        // always 0?
+    u32 Frame;
+    u32 Duration;
+    u32 DataOffset;     // offset to data in the file
+    u32 DataSize;       // size of the data stored in the file
+    u8 header_data[0x50]<hidden=true>;
+    local u32 ret = FPush();
+    FSeek(DataOffset);
+    switch (Cmd) {
+        case "FS__":
+            CommandData_FS cmd_data;
+            break;
+        default:
+            u8 cmd_data[DataSize];
+            break;
+    }
+    FPop();
+} EvtCommands<optimize=false,read=Str("Command: %s || Frame: %04d || Duration: %03d || ObjectID: %02d", Cmd, Frame, Duration, ObjectId)>;
+
+EvtHeader header;
+FSeek(header.HeaderSize);
+EvtObjects section1(header)[header.FirstSectionCount];
+EvtCommands commands[header.Field40];

--- a/templates/metaphor_evt_ecs.bt
+++ b/templates/metaphor_evt_ecs.bt
@@ -1,7 +1,7 @@
 //------------------------------------------------
 //--- 010 Editor v12.0.1 Binary Template
 //
-//      File: metpahor_evt_ecs.bt
+//      File: metaphor_evt_ecs.bt
 //   Authors: Rirurin (based on p5_evt_ecs.bt by TGE)
 //   Version: 1.0
 //   Purpose: Parse Metaphor: Refantazio evt & ecs files
@@ -14,25 +14,30 @@
 #include "common/include.h"
 
 // Math types
-typedef struct
-{
-    f32 X;
-    f32 Y;
-    f32 Z;
+
+typedef struct {
+    f32 x;
+    f32 y;
+} Vector2 <read=ReadVector2, write=WriteVector2>;
+string ReadVector2(Vector2& self) { return Str("<%g, %g>", self.x, self.y); }
+void WriteVector2(Vector2& self, string s) { SScanf(s, "<%g, %g>", self.x, self.y); }
+
+typedef struct {
+    f32 x;
+    f32 y;
+    f32 z;
 } Vector3 <read=ReadVector3, write=WriteVector3>;
+string ReadVector3(Vector3& self) { return Str("<%g, %g, %g>", self.x, self.y, self.z); }
+void WriteVector3(Vector3& self, string s) { SScanf(s, "<%g, %g, %g>", self.x, self.y, self.z); }
 
-string ReadVector3( Vector3& value )
-{
-    local char buffer[255];
-    SPrintf( buffer, "[%.6f, %.6f, %.6f]", value.X, value.Y, value.Z );
-
-    return buffer;
-}
-
-void WriteVector3( Vector3& value, string s )
-{
-    SScanf( s, "[%f, %f, %f]", value.X, value.Y, value.Z );
-}
+typedef struct {
+    u8 r;
+    u8 g;
+    u8 b;
+    u8 a;
+} ColorRGBAByte <read=ReadColorRGBAByte, write=WriteColorRGBAByte>;
+string ReadColorRGBAByte(ColorRGBAByte& self) { return Str("#%02X%02X%02X%02X", self.r, self.g, self.b, self.a); }
+void WriteColorRGBAByte(ColorRGBAByte& self, string s) { SScanf(s, "#%02X%02X%02X%02X", self.r, self.g, self.b, self.a); }
 
 typedef struct
 {
@@ -55,10 +60,970 @@ void WriteQuaternion( Quaternion& value, string s )
     SScanf( s, "[%f, %f, %f, %f]", value.X, value.Y, value.Z, value.W );
 }
 
-// Field Scene
-// Indicates which field object should be loaded as the current scene.
-typedef struct
+// Enums
+
+enum<u8> Boolean
 {
+    False = false,
+    True = true,
+};
+
+string GetBooleanString(Boolean value) {
+    string buffer;
+    if (value == False) {
+        SPrintf(buffer, "False");
+    } else {
+        SPrintf(buffer, "True");
+    }
+    return buffer;
+}
+
+enum<int> FadeType
+{
+    FadeType_None,
+    FadeType_BlackIn,
+    FadeType_BlackOut,
+    FadeType_WhiteIn,
+    FadeType_WhiteOut,
+};
+
+typedef enum<u32> {
+    CameraMoveDirectFlags_HasPosition = 1 << 0,
+    CameraMoveDirectFlags_HasRotation = 1 << 1,
+    CameraMoveDirectFlags_Flag0x4 = 1 << 2,
+    CameraMoveDirectFlags_Flag0x8 = 1 << 3,
+    CameraMoveDirectFlags_SetCameraPlane = 1 << 5,
+} ECameraMoveDirectFlags<read=CMDFlagsToString, write=StringToCMDFlags>;
+
+string CMDFlagsToString(u64 value)
+{
+    local u32 prefixLength = Strlen("CameraMoveDirectFlags_"), i;
+    local ECameraMoveDirectFlags current; local string result, currentStr;
+    for (i = 0; i <= 31; ++i) 
+    {
+        if (!(current = value & (1 << i))) continue; 
+        currentStr = SubStr(EnumToString(current), prefixLength);
+        result = i == 0 ? currentStr : Str("%s|%s", result, currentStr);
+    }
+    return result;
+}
+
+void StringToCMDFlags(ECameraMoveDirectFlags& result, string input)
+{
+    local s32 prefixLength = Strlen("CameraMoveDirectFlags_"), i, pos, nextPos;
+    local ECameraMoveDirectFlags current;
+    result = 0;
+    while (pos < Strlen(input)) {
+        nextPos = Strstr(SubStr(input, pos), "|");
+        if (nextPos == -1) nextPos = Strlen(input) - pos;
+        for (i = 0; i <= 31; ++i) {
+            current = 1 << i;
+            if (Strcmp(SubStr(EnumToString(current), prefixLength), SubStr(input, pos, nextPos)) == 0)
+                result |= current;
+        }
+        pos = pos + nextPos + 1;
+    }
+}
+
+typedef struct(u32 version) // CAMERA_MOVE_DIRECT
+{
+    ECameraMoveDirectFlags Flags; // 0x0
+    Vector3 PovPos; // 0x4
+    Vector3 RotEuler; // 0x10
+    Vector3 Fov; // 0x1c
+    u32 InterpParam; // 0x28
+    f32 FocalPlane;
+    f32 NearBlurPlane;
+    f32 FarBlurPlane;
+    f32 BlurScale;
+    f32 DOF_OC;
+    u32 DOF_10;
+    u32 GaussType;
+    f32 Field48;
+    u32 Field4C;
+    if (version > 5) {
+        f32 Field50;
+        f32 Field54;
+    }
+} CommandData_CMD;
+
+typedef struct // CAMERA_SET_ASSET
+{
+    u32 Flags;
+    u32 AssetID;
+    u32 AnimNo;
+    f32 AnimSpeed;
+    u32 AnimStartFrame;
+    Vector3 PovPos;
+    Vector3 RotEuler;
+    u32 Reserve_3_4;
+    f32 FocalPlane;
+    f32 NearBlurPlane;
+    f32 FarBlurPlane;
+    f32 BlurScale;
+    f32 Field40;
+    f32 Field44;
+    f32 Field48;
+    f32 Field4C;
+    u32 Field50;
+    f32 Field54;
+    f32 Field58;
+    u8 Field5C;
+    u8 Field5D;
+    u16 Field5E;
+    f32 Field60;
+    f32 Field64;
+} CommandData_CSA;
+
+typedef struct // CAMERA_SET_DIRECT
+{
+    u32 Flags;
+    Vector3 Position;
+    Vector3 Rotation; // in degrees
+    f32 Fov;
+    f32 Field20;
+    f32 Field24;
+    f32 Field28;
+    f32 Field2C;
+    f32 Field30;
+    f32 Field34;
+    f32 Field38;
+    f32 Field3C;
+    u32 Field40;
+    u32 Field44;
+    u32 Field48;
+    u32 Field4C;
+} CommandData_CSD;
+
+typedef struct { // CAMERA_SHAKE
+    u32 Flags;
+    u32 ShakeMode;
+    u32 Field08;
+    f32 Field0C;
+    f32 Field10;
+} CommandData_CShk;
+
+typedef struct // GAME_DATE
+{
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+    u32 Field10;
+    u32 Field14;
+    u32 Field18;
+} CommandData_Date;
+
+typedef struct // EFFECT_ALPHA
+{
+    u32 Flags;
+    ColorRGBAByte AlphaValue;
+    u32 InterpParam;
+    u32 Reserve_1_4;
+} CommandData_EAlp<read=Str("Alpha %s", ReadColorRGBAByte(AlphaValue))>;
+
+typedef struct // ENV_BGCOLOR
+{
+    u32 Flags;
+    u32 InterpParam;
+    u32 Reserve_1_3;
+    ColorRGBAByte ColorRGBA;
+} CommandData_EnBc<read=Str("BG Color %s", ReadColorRGBAByte(ColorRGBA))>;
+
+typedef struct // ENV_COLOR_CORRECTION
+{
+    u32 Field00;
+    u32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
+    u32 Field28;
+} CommandData_EnCc;
+
+typedef struct // ENV_DOF
+{
+    u32 Flags;
+    u32 InterpParam;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
+} CommandData_EnDf;
+
+typedef struct // ENV_HDR
+{
+    u32 Flags;
+    u32 InterpParam;
+    u32 Reserve_1_3;
+    u32 Reserve_1_4;
+    f32 MiddleGray;
+    f32 BloomScale;
+    f32 AdaptedLum;
+    f32 ElapsedTime;
+    u32 StarNumLines;
+    f32 StarLength;
+    f32 StarScale;
+    f32 StarGlareCA;
+    f32 StarGlareSI;
+    f32 Field34;
+    f32 Field38;
+    f32 Field3C;
+} CommandData_EnHd;
+
+typedef struct // ENV_LIGHT (ENV_LIGHT_0, ENV_LIGHT_1, ENV_LIGHT_INDEP)
+{
+    u32 Flags;
+    u32 InterpParam;
+    u32 Reserve_1_3;
+    u32 Reserve_1_4;
+    ColorRGBAByte AmbientColor;
+    ColorRGBAByte DiffuseColor;
+    ColorRGBAByte SpecularColor;
+    Vector3 Dir;
+    u32 Field28;
+    u32 Field2C;
+} CommandData_EnL0;
+
+typedef struct // ENV_OUTLINE
+{
+    u32 Flags;
+    u32 InterpParam;
+    f32 Field08;
+    f32 Field0C;
+    f32 Range;
+    f32 Width;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
+} CommandData_EnOl;
+
+typedef struct // ENV_PHYSICS
+{
+    u32 Flags;
+} CommandData_EnPh;
+
+typedef struct // ENV_SHADOW
+{
+    u32 Flags;
+    u32 InterpParam;
+    u32 Reserve_1_3;
+    u32 Reserve_1_4;
+    u32 ShadowFlags;
+    f32 DepthRange;
+    f32 Bias;
+    f32 DimmerAmb;
+    f32 DimmerDif;
+    f32 Split;
+    f32 Field28;
+    f32 Field2C;
+    f32 Field30;
+    f32 Field34;
+} CommandData_EnSh;
+
+typedef struct // ENV_SET
+{
+    u32 Flags;
+    u32 AssetID;
+} CommandData_Env<read=Str("ENV Asset ID: %d", AssetID)>;
+
+typedef struct // EFFECT_REGISTER
+{
+    u32 Flags;
+    u32 RegisterType;
+    u32 SceneType;
+    u32 Reserve_1_4;
+} CommandData_ERgs<read=Str("Reg type %d, Scene type %d", RegisterType, SceneType)>;
+
+typedef struct // EFFECT_SCALE
+{
+    u32 Flags;
+    u32 InterpParam;
+    f32 Scale;
+    u32 Reserve_1_4;
+} CommandData_EScl<read=Str("Scale: %g", Scale)>;
+
+typedef struct // EFFECT_SET_HELPER
+{
+    u32 Flags;
+    Vector3 Pos;
+    Vector3 RotEuler;
+    u32 Field1C;
+} CommandData_ESD<read=Str("| T %s | R %s |", ReadVector3(Pos), ReadVector3(RotEuler))>;
+
+typedef struct // EFFECT_SET_HELPER
+{
+    u32 Flags;
+    u16 FrameLengthIn;
+    u16 FrameLengthOut;
+    u32 InterpParamIn;
+    u32 InterpParamOut;
+    u32 TargetAssetID;
+    u32 HelperID;
+    u32 Field18;
+    u32 Field1C;
+} CommandData_ESH<read=Str("Target Asset %d, Helper ID %d", TargetAssetID, HelperID)>;
+
+typedef struct // FIELD_OBJ_ANIM_BASE
+{
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+    u32 Field10;
+    u32 Field14;
+    u32 Field18;
+    u32 Field1C;
+    u32 Field20;
+    u32 Field24;
+} CommandData_FAB;
+
+typedef struct // FADE
+{
+    u32 Field00;
+	
+    enum<u8>{
+        FadeOut = 1,
+		FadeIn = 2,
+	}FadeMode;
+	
+    u8 FadeTypeId;
+	u16 Field06;
+	u32 Field08;
+    u32 Field0C;
+    u32 Field10;
+    u32 Field14;
+    u32 Field18;
+    u32 Field1C;
+    u32 Field20;
+    u32 Field24;
+    u32 Field28;
+    u32 Field2C;
+    u32 Field30;
+    u32 Field34;
+    u32 Field38;
+    u32 Field3C;
+} CommandData_Fd<read=Str("%s: %d", EnumToString(FadeMode), FadeTypeId)>;
+
+typedef struct // FIELD_OBJ_DISP
+{
+    u32 Flags;       
+    u32 TargetObjectID;       
+    u32 Reserve_1_3;
+    u32 Reserve_1_4;
+} CommandData_FOD;
+
+typedef struct // FRAME_JUMP
+{
+    u32 FrameJump; // Frame to jump to
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+} CommandData_FrJ;
+
+typedef struct { // FRAME_UNSKIPPABLE
+    u32 Field00;
+} CommandData_Frus;
+
+typedef struct // FIELD_SCENE
+{
+    u32 Flags;
+    u32 Reserve_1_2;
+    u32 Reserve_1_3;
+    u32 Reserve_1_4;
+    Vector3 Position;
+    f32 RotYawDeg;
+    Vector3 RotBasePos;
+    f32 Field2C;
+    f32 Field30;
+    f32 Field34;
+    f32 Field38;
+    f32 Field3C;
+
+} CommandData_FS;
+
+typedef struct // GAME_FOLLOWER_RANK_UP
+{
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+} CommandData_GCAP;
+
+typedef struct // MODEL_ANIM_ADD
+{
+    u32 TrackNo;
+    u32 AnimNo;
+    u32 AnimBlendFrame;
+    f32 AnimWeight;
+    u32 AnimFlags;
+    f32 AnimSpeed;
+    u32 AnimStartFrame;
+    u32 Flags;
+} CommandData_MAA;
+
+typedef struct {
+    u32 AnimNo;
+    u16 Field04;
+    u16 Field06;
+    u32 Flags;
+    f32 Speed;
+} ModelAnimBaseAnimEntry;
+
+typedef struct // MODEL_ANIM_BASE
+{
+    ModelAnimBaseAnimEntry Anim1;
+    ModelAnimBaseAnimEntry Anim2;
+    u32 Flags;
+    u32 Anim1StartFrame;
+    u32 Anim1EndFrame;
+    u32 Anim2StartFrame;
+    u32 Anim2EndFrame;
+    u32 Anim1WaitFrame;
+} CommandData_MAB;
+
+typedef struct // MODEL_ALPHA
+{
+    u32 Flags;
+    ColorRGBAByte Alpha;
+    u32 InterpParam;
+    u8 TransparencyMode;
+    u8 Reserve_1_4_2;
+    u8 Reserve_1_4_3;
+    u8 Reserve_1_4_4;
+} CommandData_MAlp;
+
+typedef struct // MODEL_ATTACH
+{
+    u32 Flags;
+    u32 HelperID;     // BoneHelperId of Object that is having something attach to it
+    u32 TargetAssetID;         // ID of the Object that is being attached
+    u32 Reserve_1_4;
+    Vector3 Pos;
+    Vector3 RotEuler;
+    u32 Field28;
+    Vector3 Field2C;
+    Vector3 Field38;
+    u32 Field44;
+    u32 Field48;
+    f32 Field4C;
+} CommandData_MAt;
+
+typedef struct // MODEL_DETACH
+{
+    u32 Flags;
+    u32 HelperID;     // BoneHelperId of Object that is having something deatched from it
+    u32 TargetAssetID;         // ID of the Object that is being detached
+    u32 Reserve_1_4;
+    Vector3 Pos;
+    Vector3 RotEuler;
+    u32 Field28;
+    Vector3 Field2C;
+    Vector3 Field38;
+    u32 Field44;
+    u32 Field48;
+    f32 Field4C;
+} CommandData_MDt;
+
+typedef struct // MODEL_ICON
+{
+    u32 Flags;
+    u32 IconType; // Index of the emote icon
+    u32 IconIndex;
+    u32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+} CommandData_MIc;
+
+typedef struct // MODEL_LOOK_AT
+{
+    u16 Flags;
+    u16 MotionFlags;
+    u16 MotionType;
+    u16 TargetType;
+    u16 ResetPhysicsCount;
+    u16 SpeedType;
+    Vector3 Target;
+    u32 TargetAssetID;
+    u32 TargetHelperID;
+    f32 Field20;
+    f32 Field24;
+    f32 Field28;
+    f32 Field2C;
+    f32 Field30;
+} CommandData_MLa<read=Str("TGT %s", ReadVector3(Target))>;
+
+typedef struct // MODEL_MOVE_DIRECT
+{
+    struct {
+        u32 PathType;
+        u32 PointNum;
+        Vector3 Positions[ 24 ];
+    } EvtPathData<read=Str("Type %d, %d points", PathType, PointNum)>;
+    u32 Flags;
+    f32 Speed;
+    u32 MoveFrameLength;
+    u8 SpeedTypeEarly;
+    u8 SpeedTypeLate;
+    u16 Reserve_1_4;
+    u32 MoveAnimNo;
+    u32 MoveAnimBlendFrame;
+    u32 MoveAnimFlags;
+    f32 MoveAnimSpeed;
+    u32 MoveAnimStartFrame;
+    u32 MoveAnimEndFrame;
+    u32 Reserve_3_3;
+    u32 Reserve_3_4;
+    u32 WaitAnimNo;
+    u32 WaitAnimBlendFrame;
+    u32 WaitAnimFlags;
+    f32 WaitAnimSpeed;
+    u32 WaitAnimStartFrame;
+    u32 WaitAnimEndFrame;
+    u32 Field170;
+    u32 Field174;
+    u32 Field178;
+    u32 Field17C;
+} CommandData_MMD;
+
+typedef struct // MODEL_REGISTER
+{
+    u32 Flags;
+    u32 RegisterType;
+    u32 SceneType;
+    u32 Reserve_1_4;
+} CommandData_MRgs<read=Str("Reg Type %d, Scene Type %d", RegisterType, SceneType)>;
+
+typedef struct // MODEL_ROTATION
+{
+    u32 Flags;
+    Vector3 RotEuler;
+    u32 InterpParam;
+    u32 TurnFrame;
+    u32 Reserve_2_3;
+    u32 Reserve_2_4;
+    u32 TurnAnimNo;
+    u32 TurnAnimBlendFrame;
+    u32 TurnAnimFlags;
+    f32 TurnAnimSpeed;
+    u32 TurnAnimStartFrame;
+    u32 TurnAnimEndFrame;
+    u32 Reserve_4_3;
+    u32 Reserve_4_4;
+    u32 WaitAnimNo;
+    u32 WaitAnimBlendFrame;
+    u32 WaitAnimFlags;
+    f32 WaitAnimSpeed;
+    u32 WaitAnimStartFrame;
+    u32 WaitAnimEndFrame;
+    f32 Reserve_6_3;
+    f32 Reserve_6_4;
+} CommandData_MRot;
+
+typedef struct // MODEL_SCALE
+{
+    u32 Flags;
+    u32 InterpParam;
+    f32 Scale; // Scale of the object, 1 is default
+    u32 Reserve_1_4;
+} CommandData_MScl;
+
+typedef struct { // MODEL_TURN
+    u32 Field00;
+    f32 Field04;
+    f32 Field08;
+    f32 Field0C;
+} CommandData_MTr;
+
+typedef struct { // MODEL_SET_DIRECT
+    Vector3 Pos;
+    Vector3 RotEuler;
+    u32 WaitAnimNo;
+    u32 WaitAnimBlendFrame;
+    u32 WaitAnimFlags;
+    f32 WaitAnimSpeed;
+    u32 Flags;
+    u32 WaitAnimStartFrame;
+    u32 ResetPhysicsCount;
+} CommandData_MSD<read=Str("| T %s | R %s |", ReadVector3(Pos), ReadVector3(RotEuler))>;
+
+
+typedef struct  // MESSAGE
+{
+    u32 Flags;
+    u16 MsgLabelMajorID;
+    u8 MsgLabelMinorID;
+    u8 MsgLabelSubID;
+    u16 SelLabelMajorID;
+    u8 SelLabelMinorID;
+    u8 SelLabelSubID;
+    u32 SelResultIndex;
+    u16 Field10;
+    u32 Field12;
+    u32 Field16;
+    u16 Field1a;
+    u32 Field1C;
+    u32 Field20;
+    u32 Field24;
+} CommandData_Msg;
+typedef struct  // MESSAGE_VOICE
+{
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+} CommandData_MsgV;
+
+typedef struct // MOVIE_PLAY
+{
+    u32 Field00;
+    f32 Field04;
+    f32 Field08;
+} CommandData_MvPl;
+
+typedef struct // PFX_BLUR_RADIAL
+{
+    u32 Flags;
+    u16 FrameLengthIn;
+    u16 FrameLengthOut;
+    u32 InterpParamIn;
+    u32 InterpParamOut;
+    Vector2 CenterPos;
+    f32 Power;
+    f32 FallOff;
+    u32 BlendType;
+    ColorRGBAByte ColorRGBA;
+    u32 Field28;
+    u32 Field2C;
+} CommandData_PBRd<read=Str("| T %s | Power %g | Falloff %g | Col %s |", ReadVector2(CenterPos), Power, FallOff, ReadColorRGBAByte(ColorRGBA))>;
+
+typedef struct // PFX_BLUR_STRAIGHT
+{
+    u32 Flags;
+    u16 FrameLengthIn;
+    u16 FrameLengthOut;
+    u32 InterpParamIn;
+    u32 InterpParamOut;
+    f32 Direction;
+    f32 Power;
+    u32 BlendType;
+    ColorRGBAByte ColorRGBA;
+} CommandData_PBSt<read=Str("| Dir %g | Power %g | Col %s |", Direction, Power, ReadColorRGBAByte(ColorRGBA))>;
+
+typedef struct // PFX_COLOR_CORRECT
+{
+    u32 Flags;
+    u16 FrameLengthIn;
+    u16 FrameLengthOut;
+    u32 InterpParamIn;
+    u32 InterpParamOut;
+    Vector2 Pos;
+    Vector2 Size;
+    f32 Width;
+    f32 Height;
+    f32 Cyan;
+    f32 Magenta;
+    f32 Yellow;
+    f32 Dodge;
+    f32 Burn;
+    f32 Alpha;
+    u32 TextureAssetID;
+} CommandData_PCc<read=Str("| T %s | S %s |", ReadVector2(Pos), ReadVector2(Size))>;
+
+typedef struct // PFX_LENSFLARE
+{
+    u32 TemplateType;
+    Vector3 Position;
+    ColorRGBAByte ColorRGBA;
+    f32 Brightness;
+    u32 FilterType;
+    Boolean FilterVisible;
+    Boolean LightGlowVisible;
+    Boolean TerminateGlowVisible;
+    u8 Reserve;
+    u32 InterpFrameIn;
+    u32 InterpFrameOut;
+    u32 InterpParamIn;
+    u32 InterpParamOut;
+    u32 Field30;
+    u32 Field34;
+    u32 Field38;
+} CommandData_PLf;
+
+typedef struct // PAD_RUMBLE
+{
+    u32 Flag;
+    u32 Field04; // frame count?
+} CommandData_PRum;
+
+typedef struct // SCRIPT
+{
+    u32 Flags;
+    u32 ScrIndex;
+    char ScrName[0x40];
+} CommandData_Scr<read=ScrName>;
+
+// ECS
+
+typedef struct // SOUND
+{
+    u32 Flags;
+	
+    enum<u32>{
+		Bgm = 1,
+        System = 2,
+        Event = 3,
+	}SoundType;
+	
+    enum<u32>{
+		Play = 1,
+        Stop = 2,
+	}CtrlType;
+	
+    u32 ChannelNo;
+    u32 SoundNo;
+    f32 Volume;
+    u32 FadeFrame;
+    u32 Field1C;
+} CommandData_Snd<read=Str("%s %s Cue: %d, on Channel: %d", EnumToString(CtrlType), EnumToString(SoundType), SoundNo, ChannelNo)>;
+
+// METAPHOR ONLY (EVT)
+
+typedef struct { // CAMERA_SET_FIELD
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
+} CommandData_CSF;
+
+typedef struct { // ENV_CLOUD
+    u32 Flags;
+    f32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    u32 Field20;
+    u32 Field24;
+    f32 Field28;
+    f32 Field2C;
+    f32 Field30;
+    f32 Field34;
+    f32 Field38;
+    f32 Field3C;
+} CommandData_EnC;
+
+typedef struct { // ENV_CHARA_LIGHT
+    u32 Flags;
+    f32 Field04;
+    u32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    u32 Field24[0x20];
+    u32 FieldA4;
+    f32 FieldA8;
+} CommandData_EnCL;
+
+typedef struct { // ENV_DIFFUSION
+    u32 Field00;
+    u32 Field04;
+    f32 Field08;
+    f32 Field0C;
+} CommandData_EnDi;
+
+typedef struct { // ENV_EXPONENTIAL_FOG
+    u32 Field00;
+    u32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
+    f32 Field28;
+    f32 Field2C;
+    f32 Field30;
+    f32 Field34;
+    f32 Field38;
+    f32 Field3C;
+    f32 Field40;
+    f32 Field44;
+} CommandData_Enef;
+
+typedef struct { // ENV_PLANE_GRADATION
+    u32 Field00;
+    f32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
+    f32 Field28;
+    f32 Field2C;
+    f32 Field30;
+    f32 Field34;
+    f32 Field38;
+    f32 Field3C;
+} CommandData_EnPg;
+
+typedef struct { // ENV_SKYDOME
+    u32 Enabled;
+} CommandData_EnSD<read=Str("Enabled: %d", Enabled)>;
+
+typedef struct { // ENV_SSAO
+    u32 Flags;
+    u32 InterpParam;
+    u32 Reserve_1_3;
+    u32 Reserve_1_4;
+    f32 DepthRange;
+    f32 OccluderRadius;
+    f32 FalloffRadius;
+    f32 Brightness;
+    f32 BlurScale;
+} CommandData_EnSs;
+
+typedef struct { // FIELD_FEATURE_DISP
+    u32 Field00;
+} CommandData_FFD;
+
+typedef struct { // FIELD_MOB_DISP
+    u32 Field00;
+    u32 Field04;
+} CommandData_FMD;
+
+typedef struct { // FIELD_MOB_DISP_BOX
+    u32 Field00;
+    f32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
+} CommandData_FMDB;
+
+typedef struct { // FIELD_LIGHTS
+    u32 Field00;
+    f32 Field04;
+} CommandData_FL;
+
+typedef struct { // FIELD_REGISTER
+    u32 Field00;
+    u32 Field04;
+} CommandData_FR;
+
+typedef struct { // GAME_AREA_NAME
+    u32 Field00;
+} CommandData_GAn;
+
+typedef struct { // GAME_BASE_PARAM_UP
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+    u32 Field10;
+    char name[0x40];
+} CommandData_GBpu<read=name>;
+
+typedef struct { // GAME_HUMAN_PARAM_UP
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+    u32 Field10;
+    u32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
+    u32 Field28;
+    char name[0x40];
+} CommandData_GHpu<read=name>;
+
+typedef struct {
+    char name[0x40];
+} GameItemName<read=name>;
+
+typedef struct { // GAME_ITEM
+    u32 Field00;
+    u32 Field04;
+    u32 Field08[8];
+    u32 Field28[8];
+    GameItemName ItemNames[8];
+    u32 Field248;
+    GameItemName Field24C;
+} CommandData_GI;
+
+typedef struct { // GAME_MONEY
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    char name[0x40];
+} CommandData_GM;
+
+typedef struct { // GAME_NAME_ENTRY
+    u32 Field00;
+} CommandData_GNe;
+
+typedef struct { // GAME_PLAYER_NAME_ENTRY
+    u32 Field00;
+} CommandData_GPne;
+
+typedef struct { // GAME_QUEST
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    char name[0x40];
+} CommandData_GQ;
+
+typedef struct { // GAME_SORTIE_MAP
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+} CommandData_GSm;
+
+typedef struct { // GAME_TUTORIAL
+    u32 Field00;
+    u32 Field04;
+    char name[0x40];
+} CommandData_GTut;
+
+typedef struct { // MODEL_AEX
+    u32 Field00;
+    u32 Field04;
+} CommandData_MAex;
+
+typedef struct { // MOB_ANIM_BASE
     u32 Field00;
     u32 Field04;
     u32 Field08;
@@ -69,61 +1034,279 @@ typedef struct
     u32 Field1C;
     u32 Field20;
     u32 Field24;
+} CommandData_Mbab;
+
+typedef struct { // MOB_ICON
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    u32 Field1C;
+} CommandData_Mbic;
+
+typedef struct { // MOB_LOOKAT
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    u32 Field18;
+    u32 Field1C;
+} CommandData_Mbla;
+
+typedef struct { // MOB_REGISTER
+    u32 Field00;
+    u32 Field04;
+} CommandData_Mbr;
+
+typedef struct { // MOB_SET_DIRECT
+    u32 Field00;
+    f32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    u32 Field1C;
+    u32 Field20;
+    u32 Field24;
+} CommandData_Mbsd;
+
+typedef struct { // MODEL_CLOTH_ENABLE
+    u32 Field00;
+    u32 Field04;
+} CommandData_MCe;
+
+typedef struct { // MODEL_CLOTH
+    u32 Field00;
+    u32 Field04;
+} CommandData_MCPr;
+
+typedef struct { // MODEL_FACIAL_BLEND
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+    u32 Field10;
+} CommandData_MFb;
+
+typedef struct // MODEL_ICON_TERMINATE
+{
+    u32 Field00;
+} CommandData_MIct;
+
+typedef struct // MODEL_LIPSYNC
+{
+    u32 Field00;
+    f32 Field04;
+    f32 Field08;
+} CommandData_MLs;
+
+typedef struct { // MODEL_MOVE_ANIM
+    u32 Field00;
+    u32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    u32 Field24;
+} CommandData_Mma;
+
+typedef struct { // MODEL_MOVIE_START_ANIM
+    u32 Field00;
+    u32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    u32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    u32 Field24;
+} CommandData_Mmsa;
+
+typedef struct { // MODEL_OBJ_DISP
+    u32 Field00;
+    u32 Field04;
+} CommandData_MOD;
+
+typedef struct { // MODEL_PLANE_GRADATION
+    u32 Field00;
+    f32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
+    f32 Field28;
+    f32 Field2C;
+    f32 Field30;
+    f32 Field34;
+    f32 Field38;
+    f32 Field3C;
+} CommandData_MPg;
+
+typedef struct { // MASK_BLEND
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    u32 Field24;
+    u32 Field28;
+    f32 Field2C;
+    f32 Field30;
+} CommandData_mskb;
+
+typedef struct { // MASK_LAYER_BLEND
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    f32 Field24;
     u32 Field28;
     u32 Field2C;
-    u32 Field30;
-    u32 Field34;
-    u32 Field38;
-    u32 Field3C;
+    f32 Field30;
+    f32 Field34;
+} CommandData_mskl;
 
-} CommandData_FS;
+typedef struct {
+    u32 Field00;
+    f32 Field04;
+    f32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+} CommandData_PMn;
+
+typedef struct { // SUBTITLE
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+} CommandData_Subs;
+
+typedef struct { // TEX_COLOR_CORRECT
+    u32 Flags; // these fields are currently a guess, test that these are correct
+    Vector2 Pos;
+    f32 Width;
+    f32 Height;
+    f32 Cyan;
+    f32 Magenta;
+    f32 Yellow;
+    f32 Dodge;
+    f32 Burn;
+    f32 Alpha;
+} CommandData_TCc<read=Str("| T %s | %d x %d | ", ReadVector2(Pos), Width, Height)>;
+
+typedef struct { // TEXTURE
+    u32 Flags;
+    u16 FrameLengthIn;
+    u16 FrameLengthOut;
+    u32 InterpParamIn;
+    u32 InterpParamOut;
+    Vector3 Pos;
+    Vector2 Scale;
+    Vector2 TexcoordTopLeft;
+    Vector2 TexcoordBottomRight;
+    u32 RenderPrio;
+    u32 BlendType;
+    ColorRGBAByte ColorRGBA;
+} CommandData_Tex<read=Str("| T %s | S %s | C %s |", ReadVector3(Pos), ReadVector2(Scale), ReadColorRGBAByte(ColorRGBA))>;
+
+typedef struct { // WIPE
+    u32 Field00;
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+} CommandData_Wp;
+
+// METAPHOR ONLY (ECS)
+
+typedef struct { // MODEL_FOOTSTEPS
+    u32 Field00;
+    u32 Field04;
+} CommandData_MFs;
+
+typedef struct { // SOUND_AMBIENT
+    u32 Field00;
+    u32 Field04;
+    f32 Field08;
+} CommandData_SndA;
 
 typedef struct {
     SetRandomBackColor();
     char Magic[3];
     u8 SwapEndian<hidden=true>;
     u32 Version<format=hex>;
-    u16 Field08;
-    u16 Field0A;
-    u8 Field0C;
-    u8 FIeld0D;
-    u8 Field0E;
+    u16 MajorID;
+    u16 MinorID;
+    u8 Rank;
+    u8 Level;
+    u8 Chapter;
     u8 Field0F;
-    u32 Field10;
-    u32 Field14;
-    u32 Field18;
-    s32 Field1C;
-    u8 Field20;
-    u8 Field21;
-    u16 Field22;
-    u16 Field24;
+    u32 FileSize;
+    u32 FileHeaderSize;
+    u32 Flags;
+    s32 TotalFrame;
+    u8 FrameRate;
+    u8 InitScriptIndex;
+    u16 StartFrame;
+    u16 LetterBoxInFrame;
     u16 Field26;
-    u32 Field28;
-    u32 Field2C;
-    u32 FirstSectionCount;
-    u32 HeaderSize;
-    u32 FirstSectionEntrySize;
-    u32 Field3C;
-    u32 Field40;
-    u32 Field44;
-    u32 Field48;
-    u32 Field4C;
-    u32 Field50;
-    u32 Field54;
-    u32 Field58;
-    u32 Field5C;
-    u32 Field60;
-    u32 Field64;
-    u32 Field68;
-    u32 Field6C;
-    u32 Field70[8];
+    u32 InitEnvAssetID;
+    u32 InitEnvAssetIDDbg;
+    u32 AssetNums;
+    u32 AssetDataOfs;
+    u32 AssetDataSize;
+    u32 AssetReserve;
+    u32 CommandNums;
+    u32 CommandHeaderOfs;
+    u32 CommandHeaderSize;
+    u32 CommandReserve;
+    u32 MessagePathOfs;
+    u32 MessagePathSize;
+    u32 MessageFileOfs;
+    u32 MessageFileSize;
+    u32 ScriptPathOfs;
+    u32 ScriptPathSize;
+    u32 ScriptFileOfs;
+    u32 ScriptFileSize;
+    u32 MarkerFrame[8];
     u8 Field90[0x40];
     s32 FieldD0;
     s32 FieldD4;
     s32 FieldD8;
     s32 FieldDC;
     s32 FieldE0;
-} EvtHeader<read=Str("Version 0x%X", Version)>;
+} EvtHeader<read=Str("ver 0x%X, rank %d, level %d, %d frames, %d FPS", Version, Rank, Level, TotalFrame, FrameRate)>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 CommandNums;
+    u32 CommandHeaderOfs;
+    u32 CommandHeaderSize;
+    u32 CommandReserve;
+} EcsHeader;
 
 typedef struct(EvtHeader& header) {
     u32 Field00;
@@ -137,17 +1320,16 @@ typedef struct(EvtHeader& header) {
 
 typedef struct(EvtHeader& header) {
     SetRandomBackColor();
-    u32 ObjectId;
-    u32 Field04;
-    u32 Field08;
-    u32 Field0C;
-    u32 MajorId;
-    u16 Field14;
-    u16 Field16;
-    u32 Field18;
-    u32 Field1C;
-    
-    u32 Field20;
+    u32 AssetID;
+    u32 ResrcTypeID;
+    u32 ResrcCategory;
+    u32 ResrcUniqueID;
+    u32 ResrcMajorID;
+    u16 ResrcSubID;
+    u16 ResrcMinorID;
+    u32 Flags;
+    u32 BaseMotNo;
+    u32 ExtBaseMotNo;
     EvtObjectFile Field24(header);
     EvtObjectFile Field13C(header);
     EvtObjectFile Field254(header);
@@ -157,34 +1339,153 @@ typedef struct(EvtHeader& header) {
     u32 Field48C;
     u8 Field490[0x40];
     u8 Field4D0[0x40];
-} EvtObjects<optimize=false, read=Str("ID %d", ObjectId)>;
+} EvtObjects<optimize=false, read=Str("ID %d: %d_%d_%d", AssetID, ResrcMajorID, ResrcMinorID, ResrcSubID)>;
 
 typedef struct {
     SetRandomBackColor();
-    char Cmd[0x4];
-    u16 Field04;        // 0, 1, 2 usually
-    u16 Field06;        // always 0?
-    u32 ObjectId;       // reference to event object
-    u32 Field0C;        // always 0?
-    u32 Frame;
-    u32 Duration;
-    u32 DataOffset;     // offset to data in the file
-    u32 DataSize;       // size of the data stored in the file
-    u8 header_data[0x50]<hidden=true>;
+    char CommandCode[0x4];
+    u16 CommandVersion;
+    u16 CommandType;
+    u32 AssetID;
+    u32 Flags;
+    u32 FrameStart;
+    u32 FrameLength;
+    u32 CommandParamOfs;
+    u32 CommandParamSize;
+    u32 CondType;
+    u32 CondIndex;
+    u32 CondValue;
+    u32 CondCompType;
+    char CondName[0x40];
     local u32 ret = FPush();
-    FSeek(DataOffset);
-    switch (Cmd) {
-        case "FS__":
-            CommandData_FS cmd_data;
-            break;
-        default:
-            u8 cmd_data[DataSize];
-            break;
+    FSeek(CommandParamOfs);
+    switch (CommandCode) {
+        case "CMD_": CommandData_CMD cmd_data(CommandVersion); break;
+        case "CSA_": CommandData_CSA cmd_data; break;
+        case "CSD_": CommandData_CSD cmd_data; break;
+        case "CSF_": CommandData_CSF cmd_data; break;
+        case "CShk": CommandData_CShk cmd_data; break;
+        case "Date": CommandData_Date cmd_data; break;
+        case "EAlp": CommandData_EAlp cmd_data; break;
+        case "EnBc": CommandData_EnBc cmd_data; break;
+        case "EnC_": CommandData_EnC cmd_data; break;
+        case "EnCc": CommandData_EnCc cmd_data; break;
+        case "EnCL": CommandData_EnCL cmd_data; break;
+        case "EnDf": CommandData_EnDf cmd_data; break;
+        case "EnDi": CommandData_EnDi cmd_data; break;
+        case "Enef": CommandData_Enef cmd_data; break;
+        case "EnHd": CommandData_EnHd cmd_data; break;
+        case "EnL0": case "EnL1": CommandData_EnL0 cmd_data; break;
+        case "EnOl": CommandData_EnOl cmd_data; break;
+        case "EnPg": CommandData_EnPg cmd_data; break;
+        case "EnPh": CommandData_EnPh cmd_data; break;
+        case "EnSD": CommandData_EnSD cmd_data; break;
+        case "EnSh": CommandData_EnSh cmd_data; break;
+        case "EnSs": CommandData_EnSD cmd_data; break;
+        case "Env_": CommandData_Env cmd_data; break;
+        case "ERgs": CommandData_ERgs cmd_data; break;
+        case "EScl": CommandData_EScl cmd_data; break;
+        case "ESD_": CommandData_ESD cmd_data; break;
+        case "ESH_": CommandData_ESH cmd_data; break;
+        case "FAB_": CommandData_FAB cmd_data; break;
+        case "Fd__": CommandData_Fd cmd_data; break;
+        case "FFD_": CommandData_FFD cmd_data; break;
+        case "FL__": CommandData_FL cmd_data; break;
+        case "FMD_": CommandData_FMD cmd_data; break;
+        case "FMDB": CommandData_FMDB cmd_data; break;
+        case "FOD_": CommandData_FOD cmd_data; break;
+        case "FR__": CommandData_FR cmd_data; break;
+        case "FrJ_": CommandData_FrJ cmd_data; break;
+        case "Frus": CommandData_Frus cmd_data; break;
+        case "FS__": CommandData_FS cmd_data; break;
+        case "GAn_": CommandData_GAn cmd_data; break;
+        case "GBpu": CommandData_GBpu cmd_data; break;
+        case "GCAP": CommandData_GCAP cmd_data; break;
+        case "GHpu": CommandData_GHpu cmd_data; break;
+        case "GI__": CommandData_GI cmd_data; break;
+        case "GM__": CommandData_GM cmd_data; break;
+        case "GNe_": CommandData_GNe cmd_data; break;
+        case "GPne": CommandData_GPne cmd_data; break;
+        case "GQ__": CommandData_GQ cmd_data; break;
+        case "GSm_": CommandData_GSm cmd_data; break;
+        case "GTut": CommandData_GTut cmd_data; break;
+        case "MAA_": CommandData_MAA cmd_data; break;
+        case "MAB_": CommandData_MAB cmd_data; break;
+        case "MAex": CommandData_MAex cmd_data; break;
+        case "MAlp": CommandData_MAlp cmd_data; break;
+        case "MAt_": CommandData_MAt cmd_data; break;
+        case "Mbab": CommandData_Mbab cmd_data; break;
+        case "Mbic": CommandData_Mbic cmd_data; break;
+        case "Mbla": CommandData_Mbla cmd_data; break;
+        case "Mbr_": CommandData_Mbr cmd_data; break;
+        case "Mbsd": CommandData_Mbsd cmd_data; break;
+        case "MCe_": CommandData_MCe cmd_data; break;
+        case "MCPr": CommandData_MCPr cmd_data; break;
+        case "MDt_": CommandData_MDt cmd_data; break;
+        case "MFb_": CommandData_MFb cmd_data; break;
+        case "MFs_": CommandData_MFs cmd_data; break;
+        case "MIc_": CommandData_MIc cmd_data; break;
+        case "MIct": CommandData_MIct cmd_data; break;
+        case "MLa_": CommandData_MLa cmd_data; break;
+        case "MLs_": CommandData_MLs cmd_data; break;
+        case "Mma_": CommandData_Mma cmd_data; break;
+        case "MMD_": CommandData_MMD cmd_data; break;
+        case "Mmsa": CommandData_Mmsa cmd_data; break;
+        case "MOD_": CommandData_MOD cmd_data; break;
+        case "MPg_": CommandData_MPg cmd_data; break;
+        case "MRgs": CommandData_MRgs cmd_data; break;
+        case "MRot": CommandData_MRot cmd_data; break;
+        case "MScl": CommandData_MScl cmd_data; break;
+        case "MSD_": CommandData_MSD cmd_data; break;
+        case "Msg_": CommandData_Msg cmd_data; break;
+        case "MsgV": CommandData_MsgV cmd_data; break;
+        case "mskb": CommandData_mskb cmd_data; break;
+        case "mskl": CommandData_mskl cmd_data; break;
+        case "MTr_": CommandData_MTr cmd_data; break;
+        case "MvPl": CommandData_MvPl cmd_data; break;
+        case "PBRd": CommandData_PBRd cmd_data; break;
+        case "PBSt": CommandData_PBSt cmd_data; break;
+        case "PCc_": CommandData_PCc cmd_data; break;
+        case "PLf_": CommandData_PLf cmd_data; break;
+        case "PMn_": CommandData_PMn cmd_data; break;
+        case "PRum": CommandData_PRum cmd_data; break;
+        case "Scr_": CommandData_Scr cmd_data; break;
+        case "Snd_": CommandData_Snd cmd_data; break;
+        case "SndA": CommandData_SndA cmd_data; break;
+        case "Subs": CommandData_Subs cmd_data; break;
+        case "TCc_": CommandData_TCc cmd_data; break;
+        case "Tex_": CommandData_Tex cmd_data; break;
+        case "Wp__": CommandData_Wp cmd_data; break;
+        default: u8 cmd_data[CommandParamSize]; break;
     }
     FPop();
-} EvtCommands<optimize=false,read=Str("Command: %s || Frame: %04d || Duration: %03d || ObjectID: %02d", Cmd, Frame, Duration, ObjectId)>;
+} EvtCommands<optimize=false,read=Str("Command: %s || Version: %02d || Frame: %04d || Duration: %03d || ObjectID: %02d", CommandCode, CommandVersion, FrameStart, FrameLength, AssetID)>;
 
-EvtHeader header;
-FSeek(header.HeaderSize);
-EvtObjects section1(header)[header.FirstSectionCount];
-EvtCommands commands[header.Field40];
+local string filePath = GetFileName();
+local string fileName = FileNameGetBase( filePath, false );
+local string fileExt = FileNameGetExtension( filePath );
+
+switch (fileExt) {
+    case ".EVT":
+        EvtHeader header;
+        FSeek(header.FileHeaderSize);
+        EvtObjects section1(header)[header.AssetNums];
+        EvtCommands commands[header.CommandNums];
+        if (header.MessagePathOfs > 0) {
+            FSeek(header.MessagePathOfs);
+            char MessagePath[header.MessagePathSize];
+        }
+        if (header.ScriptPathOfs > 0) {
+            FSeek(header.ScriptPathOfs);
+            char ScriptPath[header.ScriptPathSize];
+        }
+        break;
+    case ".ECS":
+        EcsHeader header;
+        FSeek(header.CommandHeaderOfs);
+        EvtCommands commands[header.CommandNums];
+        break;
+    default:
+        Assert(false, Str("Unsupported file extension %s", fileExt));
+        break;
+}

--- a/templates/metaphor_fld.bt
+++ b/templates/metaphor_fld.bt
@@ -1,0 +1,420 @@
+//------------------------------------------------
+//--- 010 Editor v12.0.1 Binary Template
+//
+//      File: metaphor_fld.bt
+//   Authors: Rirurin
+//   Version: 1.0
+//   Purpose: Parse Metaphor: Refantazio field files
+//  Category: 
+// File Mask: *.acttbl, *.act, *.doortbl, *.eff, *.enmtbl, *.enm, *gpstbl, *.gem, *.gmk, *.hourtbl, *.ladtbl, *.plt, *.bbx, *.mps, *.npctbl, *.mobtbl, *.pcd, *.pos, *.layout, *.crv, *.tbx
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#include "common/include.h";
+
+// Common types
+
+typedef struct {
+    f32 x;
+    f32 y;
+    f32 z;
+} Vector3 <read=ReadVector3>;
+
+string ReadVector3(Vector3& self) {
+    string buffer;
+    SPrintf(buffer, "<%g, %g, %g>", self.x, self.y, self.z);
+    return buffer;
+}
+
+typedef struct {
+    f32 x;
+    f32 y;
+    f32 z;
+    f32 w;
+} Vector4 <read=ReadVector4>;
+
+string ReadVector4(Vector4& self) {
+    string buffer;
+    SPrintf(buffer, "<%g, %g, %g, %g>", self.x, self.y, self.z, self.w);
+    return buffer;
+}
+
+// Resource Background types
+
+typedef struct {
+    SetRandomBackColor();
+    char Magic[4];
+    u32 type;
+    u32 ver;
+    u32 count;
+} resrcBgDataHeader<read=Str("%s (type %d): ver %x, %d entries", Magic, type, ver, count)>;
+
+typedef struct {
+    u32 id;
+    char name[0x40];
+} resrcBgData_Entry_Common;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    if (ver > 0x20200712) {
+        u32 Field68;
+        u8 filler[0x34];
+    } else {
+        u8 filler[0x38];
+    }
+} resrcBgData_pos_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    Vector3 v4;
+    if (ver > 0x20200712) {
+        u32 values_ex[3];
+        u8 filler[0x20];
+    } else {
+        u8 filler[0x2c];
+    }
+} resrcBgData_collis_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    if (ver > 0x20200712) {
+        u32 values_ex;
+        u8 filler[0x34];
+    } else {
+        u8 filler[0x38];
+    }
+    
+} resrcBgData_npc_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    u16 v0;
+    u16 v1;
+    u16 v2;
+    u16 v3;
+    local u32 filler_size = 0x30;
+    if (ver > 0x20200712) {
+        u32 v4;
+        filler_size = 0x2c;
+    }
+    if (ver > 0x20211014) {
+        u16 v5;
+        u16 v6;
+        filler_size = 0x28;
+    }
+    u8 filler[filler_size];
+    
+} resrcBgData_tbox_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    u16 v0;
+    u16 v1;
+    u16 v2;
+    u16 v3;
+    local u32 filler_size = 0x30;
+    if (ver > 0x20200712) {
+        u32 v4;
+        filler_size = 0x2c;
+    }
+    if (ver > 0x20211014) {
+        u16 v5;
+        u16 v6;
+        filler_size = 0x28;
+    }
+    if (ver > 0x20220530) {
+        u32 v7;
+        filler_size = 0x24;
+    }
+    u8 filler[filler_size];
+    
+} resrcBgData_obj_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    Vector3 v4;
+    local u32 filler_size = 0x2c;
+    if (ver > 0x20200712) {
+        u32 v5;
+        filler_size = 0x28;
+    }
+    u8 filler[filler_size];
+} resrcBgData_action_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    Vector3 v4;
+    u32 v5;
+    u32 v6;
+    u8 filler[0x24];
+} resrcBgData_bbox_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    u16 v4;
+    u16 v5;
+    u16 v6;
+    u16 padding;
+    u32 v7;
+    u8 filler[0x2c];
+    char eplName[0x100];
+} resrcBgData_effect_Entry<read=Str("%s\t (%s) | T %s | R %s | S %s |", id.name, eplName, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    u16 v4;
+    u16 v5;
+    u16 v6;
+    u16 padding;
+    u32 v7;
+    u8 filler[0x2c];
+} resrcBgData_mission_pos_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
+    Vector3 v4;
+    u64 v5;
+    u32 v6;
+    u8 filler[0x20];
+} resrcBgData_collis_GAYA_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+// Excel File types
+
+typedef struct {
+    SetRandomBackColor();
+    char Magic[8];
+    u32 count;
+    u32 resrv;
+} fldExcelCnvData;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[160];
+} fldActionHitLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x70];
+} fldDoorLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x28];
+} fldEnemyLayout_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x2c];
+} fldGatherLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xec];
+} fldGimmickLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xcc];
+} fldGayaHitLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x80];
+} fldScriptHitLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x98];
+} fldHourNpcLayout_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x34];
+} fldLadderLinkLayout_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x2c];
+} fldTboxLink_Data<optimize=false>;
+
+// Spline
+typedef struct {
+    SetRandomBackColor();
+    char Magic[0x10]; // FIELD_CURVE
+} splineHeader;
+typedef struct {
+    u32 HasValue;
+    u32 Count;
+    u32 Offset;
+    u32 Resrv;
+} splineEntryHead;
+typedef struct {
+    SetRandomBackColor();
+    char name[0x40];
+    splineEntryHead head;
+    FPush();
+    FSeek(head.Offset);
+    Vector4 points[head.Count];
+    FPop();
+} splineEntry<read=name, optimize=false>;
+
+// Parse file
+
+local string filePath = GetFileName();
+local string fileName = FileNameGetBase( filePath, false );
+local string fileExt = FileNameGetExtension( filePath );
+
+switch (fileExt) {
+    // Resource Background
+    case ".pos": // 1
+    case ".hit": // 2
+    case ".npc": // 3
+    case ".enm": // 4
+    case ".tbx": // 5
+    case ".gem": // 6
+    case ".gmk": // 7
+    case ".ob1": // 8
+    case ".act": // 9
+    case ".bbx": // 10
+    case ".eff": // 11
+    //case ".plt": // 12
+    case ".mps": // 14
+    case ".ght": // 17
+        resrcBgDataHeader head;
+        switch (head.type) {
+            case 1:
+                resrcBgData_pos_Entry body(head.ver)[head.count];
+                break;
+            case 2:
+                resrcBgData_collis_Entry body(head.ver)[head.count];
+                break;
+            case 3:
+            case 4:
+                resrcBgData_npc_Entry body(head.ver)[head.count];
+                break;
+            case 5:
+            case 6:
+            case 7:
+                resrcBgData_tbox_Entry body(head.ver)[head.count];
+                break;
+            case 8:
+                resrcBgData_obj_Entry body(head.ver)[head.count];
+                break;
+            case 9:
+                resrcBgData_action_Entry body(head.ver)[head.count];
+                break;
+            case 10:
+                resrcBgData_bbox_Entry body(head.ver)[head.count];
+                break;
+            case 11:
+                resrcBgData_effect_Entry body(head.ver)[head.count];
+                break;
+            case 14:
+                resrcBgData_mission_pos_Entry body(head.ver)[head.count];
+                break;
+            case 17:
+                resrcBgData_collis_GAYA_Entry body(head.ver)[head.count];
+                break;
+            default:
+                Assert(false, Str("Unimplemented resrcBg type %d", type));
+                break;
+        }
+        break;
+    // Excel files
+    case ".acttbl":
+    case ".doortbl":
+    case ".enmtbl":
+    case ".gpstbl":
+    case ".gmctbl":
+    case ".ghttbl":
+    case ".hittbl":
+    case ".hourtbl":
+    case ".ladtbl":
+    case ".tbxtbl":
+        fldExcelCnvData head;
+        switch (head.Magic) {
+            case "ACTTBL":
+                fldActionHitLink_Data body[head.count];
+                break;
+            case "DORTBL":
+                fldDoorLink_Data body[head.count];
+                break;
+            case "ENMTBL":
+                fldEnemyLayout_Data body[head.count];
+                break;
+            case "GPSTBL":
+                fldGatherLink_Data body[head.count];
+                break;
+            case "GMCTBL":
+                fldGimmickLink_Data body[head.count];
+                break;
+            case "GAYATBL":
+                fldGayaHitLink_Data body[head.count];
+                break;
+            case "HITTBL":
+                fldScriptHitLink_Data body[head.count];
+                break;
+            case "HOURTBL":
+                fldHourNpcLayout_Data body[head.count];
+                break;
+            case "LADTBL":
+                fldLadderLinkLayout_Data body[head.count];
+                break;
+            case "TBXTBL":
+                fldTboxLink_Data body[head.count];
+                break;
+        }
+        break;
+    // Spline
+    case ".crv":
+        splineHeader head;
+        splineEntryHead first_entry;
+        splineEntry points[first_entry.Count];
+        break;
+    // Layout
+    // Camera Path
+    default:
+        Assert(false, Str("Unimplemented file extension %s", fileExt));
+        break;
+}

--- a/templates/metaphor_fld.bt
+++ b/templates/metaphor_fld.bt
@@ -4,7 +4,7 @@
 //      File: metaphor_fld.bt
 //   Authors: Rirurin
 //   Version: 1.0
-//   Purpose: Parse Metaphor: Refantazio field files
+//   Purpose: Parse Metaphor: Refantazio field files (COMMON\field\source, COMMON\init\data)
 //  Category: 
 // File Mask: *.acttbl, *.act, *.doortbl, *.eff, *.enmtbl, *.enm, *gpstbl, *.gem, *.gmk, *.hourtbl, *.ladtbl, *.plt, *.bbx, *.mps, *.npctbl, *.mobtbl, *.pcd, *.pos, *.layout, *.crv, *.tbx
 //  ID Bytes: 
@@ -20,12 +20,7 @@ typedef struct {
     f32 y;
     f32 z;
 } Vector3 <read=ReadVector3>;
-
-string ReadVector3(Vector3& self) {
-    string buffer;
-    SPrintf(buffer, "<%g, %g, %g>", self.x, self.y, self.z);
-    return buffer;
-}
+string ReadVector3(Vector3& self) { return Str("<%g, %g, %g>", self.x, self.y, self.z); }
 
 typedef struct {
     f32 x;
@@ -33,12 +28,18 @@ typedef struct {
     f32 z;
     f32 w;
 } Vector4 <read=ReadVector4>;
+string ReadVector4(Vector4& self) { return Str("<%g, %g, %g, %g>", self.x, self.y, self.z, self.w); }
 
-string ReadVector4(Vector4& self) {
-    string buffer;
-    SPrintf(buffer, "<%g, %g, %g, %g>", self.x, self.y, self.z, self.w);
-    return buffer;
-}
+typedef struct {
+    u8 data[0x10];
+} MsgHash<read=ReadMsgHash>;
+string ReadMsgHash(MsgHash& self) { 
+    return Str("[%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X]", 
+    self.data[0], self.data[1], self.data[2], self.data[3],
+    self.data[4], self.data[5], self.data[6], self.data[7],
+    self.data[8], self.data[9], self.data[10], self.data[11],
+    self.data[12], self.data[13], self.data[14], self.data[15]
+);}
 
 // Resource Background types
 
@@ -199,6 +200,25 @@ typedef struct(u32 ver) {
     Vector3 Translation;
     Vector3 Rotation;
     Vector3 Scale;
+    f32 v4;
+    f32 v5;
+    f32 v6;
+    f32 v7;
+    f32 v8;
+    f32 v9;
+    f32 v10;
+    f32 v11;
+    f32 v12;
+    u32 v13;
+    u8 filler[0x10];
+} resrcBgData_plight_Entry<read=Str("%s\t | T %s | R %s | S %s |", id.name, ReadVector3(Translation), ReadVector3(Rotation), ReadVector3(Scale)), optimize=false>;
+
+typedef struct(u32 ver) {
+    SetRandomBackColor();
+    resrcBgData_Entry_Common id;
+    Vector3 Translation;
+    Vector3 Rotation;
+    Vector3 Scale;
     u16 v4;
     u16 v5;
     u16 v6;
@@ -226,7 +246,7 @@ typedef struct {
     char Magic[8];
     u32 count;
     u32 resrv;
-} fldExcelCnvData;
+} fldExcelCnvData<read=Str("%s: %d entries", Magic, count)>;
 
 typedef struct {
     SetRandomBackColor();
@@ -278,6 +298,552 @@ typedef struct {
     u8 data[0x2c];
 } fldTboxLink_Data<optimize=false>;
 
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x2c];
+} fldObjLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x194];
+} fldNpcLayout_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x40];
+} fldMobLayout_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x174];
+} fldAttackDefine_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x3c];
+} fldCameraDefine_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x60];
+} fldClassLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u16 Field00;
+    u16 Field02;
+    MsgHash msg[4];
+} fldDinnerArchetype_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    MsgHash msg0;
+} fldDinnerEnd_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x4c];
+} fldDinnerPlan_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x40];
+} fldDinnerStay_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x64];
+} fldDungeonGrid_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x34];
+} fldEnemyDefine_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u16 Field00;
+    u16 Field02;
+    char name[0x20];
+} fldHourSeason_Data<read=name, optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x64];
+} fldKeyFreeHint_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x7c];
+} fldMapCharaLight_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data;
+} fldMapEventIconDefine_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x48];
+} fldMemberFormation_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x20];
+} fldMemberLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    f32 data;
+} fldMiscDefine_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x7c];
+} fldMobGroup_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x24];
+} fldMobLookAwaySeason_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x90];
+} fldReportLink_Data<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x2c];
+} fldEncountPack<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x34];
+} fldEventLink<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x30];
+} fldEventReward<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x82];
+} fldAccessSpotList<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x44];
+} fldDinnerRival<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x44];
+} fldDinnerSpot<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x44];
+} fldDinnerStatus<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x4c];
+} fldDinnerQuest<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data;
+} fldSpecialDay<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xc8];
+} fldMorningStatus<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x244];
+} fldMorningTravel<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x30];
+} fldMorningQuest<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x44];
+} fldMapBgm<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xd0];
+} fldD07_GKDefine<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xec];
+} fldQuestDungeon<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x24];
+} fldMapLink<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data;
+} fldTravelPath<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x350];
+} fldTravelPoint<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xa8];
+} fldEnvLink<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x44];
+} fldCharaLink<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x98];
+} fldPresetData_ArcheTypeCategoryEquip<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x84];
+} fldPresetData_Character<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x204];
+} fldPresetData_Counter<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x84];
+} fldPresetData_Flag<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x18];
+} fldPresetData_Follower<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x104];
+} fldPresetData_Item<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x200];
+} fldPresetData_Misc<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x5c];
+} fldPresetData_Party<optimize=false>;
+
+// init/data
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x18];
+} initAbilityTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data[2];
+} initAddContentItemTable<optimize=false>;
+
+typedef struct {
+    char data[0x10];
+} initAddContentTableName<read=data>;
+
+typedef struct {
+    SetRandomBackColor();
+    u16 id;
+    initAddContentTableName name;
+    u8 pad0;
+    initAddContentTableName id;
+    u8 pad1;
+} initAddContentTable<read=Str("%s: %s", name.data, id.data), optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x24];
+} initAreaName<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data[2];
+} initAreaNameLogo_Camp<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x1c];
+} initAreaNameLogo_Event<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data;
+} initAreaNameLogo_Village<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x10];
+} initATCategoryTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x18];
+} initBgMapData<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x40];
+} initBountyCounter<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    MsgHash msg;
+} initBountySpotTitleID<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    MsgHash msg[2];
+} initCalendar<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x12];
+} initCalendarOpenMessage<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x6c];
+} initCharaID<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x24];
+} initCueToChannel<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x38];
+} initDaily<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x104];
+} initDebugFlagCounterSet<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x12];
+} initEnemyID<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 color;
+} initFadeColor<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xc];
+} initFollowerItemEffect<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xa];
+} initFollowerCheckTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x18a0];
+} initFollowerLayout<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x418];
+} initFollowerRankUp<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x1e];
+} initFollowerTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x48];
+} initGallicaTalk<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x38];
+} initGallicaTalkPlayspot<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x84];
+} initGallicaTalkQuest<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x68];
+} initGallicaTalkTown<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data[2];
+} initKEISYO<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data[4];
+} initLottoTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x2c];
+} initMapData<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    MsgHash hash[2];
+} initMapNameTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x48];
+} initMapShortcut<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data;
+} initMsgIcon<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data;
+} initNGPlus<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    char name[0x20];
+} initNovel<read=name, optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x20];
+} initNpcId<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x16];
+} initPcParamTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xc];
+} initQuestDropTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0xe0];
+} initQuest<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x1e0];
+} initQuestNpcLayout<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x14];
+} initQuestProgression<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data;
+} initQuestRequiredItemsEx<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x44];
+} initQuestVoice<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x44];
+} initQuestVoice2<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x42];
+} initResrcNpcModelComb<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x98];
+} initResrcSndEnv<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u8 data[0x14];
+} initShopTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u16 shopType;
+} initShopTypeTable<read=Str("%d", shopType), optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data[0x3];
+} initSummonItemData<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data[2];
+} initTravelersVoiceDTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data[2];
+} initTravelersVoiceTable<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data[3];
+} initWipeAreaChangeData<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 data[2];
+} initWipeAreaChangeDataCategory<optimize=false>;
+
+typedef struct {
+    SetRandomBackColor();
+    u32 values[4];
+    char wipe_in_usm[0x40];
+    char wipe_load_usm[0x40];
+    char wipe_out_usm[0x40];
+    char wipe_spr_out[0x20];
+    char wipe_spr_in[0x20];
+    u8 data[0x38];
+    char wipe_spr_cond[0x20];
+} initWipeData<optimize=false>;
+
 // Spline
 typedef struct {
     SetRandomBackColor();
@@ -299,6 +865,190 @@ typedef struct {
     FPop();
 } splineEntry<read=name, optimize=false>;
 
+// Camera path
+typedef struct {
+    SetRandomBackColor();
+    u32 ver;
+    u32 Field04;
+    f32 Field08;
+    u32 SectionCounts[8];
+} pcdHeader;
+typedef struct(u32 ver) {
+    switch (ver) {
+        case 1:
+            u8 data[0x14];
+            break;
+        case 2:
+            u8 data[0x30];
+            break;
+        case 3:
+            u8 data[0x50];
+            break;
+        case 4:
+            u8 data[0x70];
+            break;
+    }
+} pcdData<optimize=false>;
+
+// Layout
+typedef struct {
+    SetRandomBackColor();
+    char Magic[4];
+    u32 Field04;
+    u32 Field08;
+    u32 Field0C;
+    u32 Objects;
+    u32 ObjectStart;
+    u32 Imports;
+    u32 BodyStart;
+} layoutHeader;
+
+typedef struct {
+    SetRandomBackColor();
+    char filename[0x5c];
+    f32 Field5C[4];
+    u32 Field6C;
+} layoutDependency<read=filename, optimize=false>;
+
+typedef struct {
+    Vector3 Translation<name="Translation">;
+    u32 Field0C<hidden=true>;
+    Vector4 Rotation<name="Rotation">;
+    Vector3 Scale<name="Scale">;
+    u32 Field2C<hidden=true>;
+    u32 Field30;
+    u32 Field34;
+    u32 Field38;
+    u32 Field3C;
+    u32 Field40;
+    u32 Field44;
+    u32 Entries;
+    u32 EntryStart;
+} layoutObjectStart<optimize=false>;
+
+typedef struct(u32 _major, u32 _minor) {
+    local u32 major = _major;
+    local u32 minor = _minor;
+    u8 Field90;
+    u8 Field91;
+    u8 Field92;
+    u8 Field93;
+    f32 Field94;
+    u32 Flags;
+    u32 Field9C;
+    u32 FieldA0;
+    u8 filler[0x1c]<hidden=true>;
+} layoutObjectEntry_Obj<read=Str("COMMON/model/field/object/o_%04d_%03d_00.GMD", major, minor)>;
+
+typedef struct {
+    f32 Field90;
+    f32 Field94;
+    f32 Field88;
+    f32 Field9C;
+    f32 FieldA0;
+    f32 FieldA4;
+    f32 FieldA8;
+    f32 FieldAC;
+    f32 FieldB0;
+    u8 filler[0xc]<hidden=true>;
+} layoutObjectEntry_Plight;
+
+typedef struct {
+    f32 Field90;
+    f32 Field94;
+    f32 Field88;
+    f32 Field9C;
+    f32 FieldA0;
+    f32 FieldA4;
+    f32 FieldA8;
+    f32 FieldAC;
+    f32 FieldB0;
+    f32 FieldB4;
+    f32 FieldB8;
+    f32 FieldBC;
+} layoutObjectEntry_Slight;
+
+typedef struct {
+    u32 Field90;
+    u32 Field94;
+    f32 Field98;
+    f32 Field9C;
+    f32 FieldA0;
+    u8 filler[0x1c]<hidden=true>;
+} layoutObjectEntry_Box;
+
+typedef struct {
+    u32 Field90;
+    f32 Field94;
+    f32 Field98;
+    f32 Field9C;
+    f32 FieldA0;
+    f32 FieldA4;
+    u32 FieldA8;
+    f32 FieldAC;
+    f32 FieldB0;
+    f32 FieldB4;
+    f32 FieldB8;
+    u32 FieldBC;
+} layoutObjectEntry_Camera;
+
+typedef struct {
+    SetRandomBackColor();
+    char type[0x8];
+    char name[0x38];
+    u32 major<name="Resource Major ID">;
+    u32 minor<name="Resource Minor ID">;
+    u32 pad2;
+    u32 Field4C;
+    u32 Field50;
+    u32 Field54;
+    f32 Field58;
+    u32 Field5C;
+    Vector3 Translation<name="Translation">;
+    u32 Field6C<hidden=true>;
+    Vector4 Rotation<name="Rotation">;
+    Vector3 Scale<name="Scale">;
+    u32 Field8C;
+    switch (type) {
+        case "obj":
+            layoutObjectEntry_Obj data(major, minor);
+            break;
+        case "gppos":
+        case "enms":
+        case "enmg":
+        case "effect":
+            u8 data[0x30]<hidden=true>;
+            break;
+        case "p-light":
+            layoutObjectEntry_Plight data;
+            break;
+        case "s-light":
+            layoutObjectEntry_Slight data;
+            break;
+        case "box":
+            layoutObjectEntry_Box data;
+            break;
+        case "cmr_fix":
+        case "cmr_trc":
+        case "cmr_pth":
+        case "cmr_def":
+            layoutObjectEntry_Camera data;
+            break;
+        default:
+            u8 data[0x30];
+            break;
+    }
+} layoutObjectEntry<read=Str("%s: %s [ %d_%d ] | T %s | R %s | S %s |", type, name, major, minor, ReadVector3(Translation), ReadVector4(Rotation), ReadVector3(Scale)), optimize=false>;
+typedef struct {
+    SetRandomBackColor();
+    layoutObjectStart start;
+    layoutObjectEntry data[start.Entries];
+} layoutObject<optimize=false, read=Str("%d entries", start.Entries)>;
+
+string PrintBadFileMagic(string& filename) {
+    return Str("File %s has an incorrect magic value", filename);
+}
+
 // Parse file
 
 local string filePath = GetFileName();
@@ -318,9 +1068,13 @@ switch (fileExt) {
     case ".act": // 9
     case ".bbx": // 10
     case ".eff": // 11
-    //case ".plt": // 12
+    case ".plt": // 12
+    // 13 (resrcBgData_slight)
     case ".mps": // 14
+    // 15 (resrcBgData_gathering)
+    // 16 (resrcBgData_collis_BTL)
     case ".ght": // 17
+    // >= 18 (resrcBgData_aix)
         resrcBgDataHeader head;
         switch (head.type) {
             case 1:
@@ -350,6 +1104,9 @@ switch (fileExt) {
             case 11:
                 resrcBgData_effect_Entry body(head.ver)[head.count];
                 break;
+            case 12:
+                resrcBgData_plight_Entry body(head.ver)[head.count];
+                break;
             case 14:
                 resrcBgData_mission_pos_Entry body(head.ver)[head.count];
                 break;
@@ -372,6 +1129,9 @@ switch (fileExt) {
     case ".hourtbl":
     case ".ladtbl":
     case ".tbxtbl":
+    case ".objtbl":
+    case ".mobtbl":
+    case ".npctbl":
         fldExcelCnvData head;
         switch (head.Magic) {
             case "ACTTBL":
@@ -404,6 +1164,18 @@ switch (fileExt) {
             case "TBXTBL":
                 fldTboxLink_Data body[head.count];
                 break;
+            case "OBJTBL":
+                fldObjLink_Data body[head.count];
+                break;
+            case "NPCTBL":
+                fldNpcLayout_Data body[head.count];
+                break;
+            case "MOBTBL":
+                fldMobLayout_Data body[head.count];
+                break;
+            default:
+                Assert(false, Str("Unimplemented excel format %s", head.Magic));
+                break;
         }
         break;
     // Spline
@@ -413,7 +1185,561 @@ switch (fileExt) {
         splineEntry points[first_entry.Count];
         break;
     // Layout
+    case ".layout":
+        FPush();
+        FPush();
+        layoutHeader head;
+        FPop();
+        FSeek(FTell() + head.BodyStart);
+        if (head.Imports > 0)
+            layoutDependency imports[head.Imports];
+        FPop();
+        FSeek(FTell() + head.ObjectStart);
+        if (head.Objects > 0)
+            layoutObject objects[head.Objects];
+        break;
     // Camera Path
+    case ".pcd":
+        pcdHeader head;
+        local u32 count = 0;
+        for (count = 0; count < 8; count++) {
+            SetRandomBackColor();
+            pcdData data(head.ver)[head.SectionCounts[count]];
+        }
+        break;
+    // binary DB file, this is likely a singleton. check by filename
+    case ".bin":
+        switch (fileName) {
+            // EXCEL FILES
+            case "Attack_Data":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ATKDEF", PrintBadFileMagic(fileName));
+                fldAttackDefine_Data body[head.count];
+                break;
+            case "Camera_Data":
+                fldExcelCnvData head;
+                Assert(head.Magic == "CAMERA", PrintBadFileMagic(fileName));
+                fldCameraDefine_Data body[head.count];
+                break;
+            case "Fast_AType_ACT_Data":
+                fldExcelCnvData head;
+                Assert(head.Magic == "CLASLNK", PrintBadFileMagic(fileName));
+                fldClassLink_Data body[head.count];
+                break;
+            case "DinnerArchetype":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DIN_ARC", PrintBadFileMagic(fileName));
+                fldDinnerArchetype_Data body[head.count];
+                break;
+            case "DinnerEnd":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DIN_END", PrintBadFileMagic(fileName));
+                fldDinnerEnd_Data body[head.count];
+                break;
+            case "DinnerGeneral":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DIN_GEN", PrintBadFileMagic(fileName));
+                fldDinnerArchetype_Data body[head.count];
+                break;
+            case "DinnerPlan":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DIN_PLA", PrintBadFileMagic(fileName));
+                fldDinnerPlan_Data body[head.count];
+                break;
+            case "DinnerStay":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DIN_STY", PrintBadFileMagic(fileName));
+                fldDinnerStay_Data body[head.count];
+                break;
+            case "Enemy_Data":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ENMDEF", PrintBadFileMagic(fileName));
+                fldEnemyDefine_Data body[head.count];
+                break;
+            case "HourSeason":
+                fldExcelCnvData head;
+                Assert(head.Magic == "HSEASON", PrintBadFileMagic(fileName));
+                fldHourSeason_Data body[head.count];
+                break;
+            case "KeyFreeHint":
+                fldExcelCnvData head;
+                Assert(head.Magic == "HINT", PrintBadFileMagic(fileName));
+                fldKeyFreeHint_Data body[head.count];
+                break;
+            case "MapCharaLight":
+                fldExcelCnvData head;
+                Assert(head.Magic == "Light", PrintBadFileMagic(fileName));
+                fldMapCharaLight_Data body[head.count];
+                break;
+            case "MapEventIcon":
+                fldExcelCnvData head;
+                Assert(head.Magic == "EVEICON", PrintBadFileMagic(fileName));
+                fldMapEventIconDefine_Data body[head.count];
+                break;
+            case "MemberFormation":
+                fldExcelCnvData head;
+                Assert(head.Magic == "F", PrintBadFileMagic(fileName));
+                fldMemberFormation_Data body[head.count];
+                break;
+            case "MemberLink":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MemberI", PrintBadFileMagic(fileName));
+                fldMemberLink_Data body[head.count];
+                break;
+            case "MiscDefine":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MISCDEF", PrintBadFileMagic(fileName));
+                fldMiscDefine_Data body[head.count];
+                break;
+            case "MobGroup_Data":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MOBGRP", PrintBadFileMagic(fileName));
+                fldMobGroup_Data body[head.count];
+                break;
+            case "MobLookAwaySeason_Data":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MOBLAS", PrintBadFileMagic(fileName));
+                fldMobLookAwaySeason_Data body[head.count];
+                break;
+            case "ReportData":
+                fldExcelCnvData head;
+                Assert(head.Magic == "REPTBL", PrintBadFileMagic(fileName));
+                fldReportLink_Data body[head.count];
+                break;
+            // FIELD SINGLETONS
+            case "Pack":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ASLIST", PrintBadFileMagic(fileName));
+                fldEncountPack body[head.count];
+                break;
+            case "EventLink":
+                fldExcelCnvData head;
+                Assert(head.Magic == "EVTLINK", PrintBadFileMagic(fileName));
+                fldEventLink body[head.count];
+                break;
+            case "EventReward":
+                fldExcelCnvData head;
+                Assert(head.Magic == "EVEREW", PrintBadFileMagic(fileName));
+                fldEventReward body[head.count];
+                break;
+            case "AccessSpotList":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ASLIST", PrintBadFileMagic(fileName));
+                fldAccessSpotList body[head.count];
+                break;
+            case "DinnerRival":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DIN_RIV", PrintBadFileMagic(fileName));
+                fldDinnerRival body[head.count];
+                break;
+            case "DinnerSpot":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DIN_SPO", PrintBadFileMagic(fileName));
+                fldDinnerSpot body[head.count];
+                break;
+            case "DinnerStatus":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DIN_STA", PrintBadFileMagic(fileName));
+                fldDinnerStatus body[head.count];
+                break;
+            case "DinnerQuest":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DIN_QUE", PrintBadFileMagic(fileName));
+                fldDinnerQuest body[head.count];
+                break;
+            case "SpecialDay":
+                fldExcelCnvData head;
+                Assert(head.Magic == "SPEDAY", PrintBadFileMagic(fileName));
+                fldSpecialDay body[head.count];
+                break;
+            case "MorningStatus":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MSTATUS", PrintBadFileMagic(fileName));
+                fldMorningStatus body[head.count];
+                break;
+            case "MorningTraval":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MTRAVAL", PrintBadFileMagic(fileName));
+                fldMorningTravel body[head.count];
+                break;
+            case "MapBgm":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MAPBGM", PrintBadFileMagic(fileName));
+                fldMapBgm body[head.count];
+                break;
+            case "D07_GK":
+                fldExcelCnvData head;
+                Assert(head.Magic == "D07GK", PrintBadFileMagic(fileName));
+                fldD07_GKDefine body[head.count];
+                break;
+            case "QuestDungeon":
+                fldExcelCnvData head;
+                Assert(head.Magic == "QUESTD", PrintBadFileMagic(fileName));
+                fldQuestDungeon body[head.count];
+                break;
+            case "PreSetData_ArcheTypeCategoryEquip":
+                fldExcelCnvData head;
+                Assert(head.Magic == "PSETCE", PrintBadFileMagic(fileName));
+                fldPresetData_ArcheTypeCategoryEquip body[head.count];
+                break;
+            case "PreSetData_Counter":
+                fldExcelCnvData head;
+                Assert(head.Magic == "PSCUNT", PrintBadFileMagic(fileName));
+                fldPresetData_Counter body[head.count];
+                break;
+            case "PreSetData_Flag":
+                fldExcelCnvData head;
+                Assert(head.Magic == "PSFLAG", PrintBadFileMagic(fileName));
+                fldPresetData_Flag body[head.count];
+                break;
+            case "PreSetData_Follower":
+                fldExcelCnvData head;
+                Assert(head.Magic == "Follow", PrintBadFileMagic(fileName));
+                fldPresetData_Follower body[head.count];
+                break;
+            case "PreSetData_Item":
+                fldExcelCnvData head;
+                Assert(head.Magic == "PSETIT", PrintBadFileMagic(fileName));
+                fldPresetData_Item body[head.count];
+                break;
+            case "PreSetData_Misc":
+                fldExcelCnvData head;
+                Assert(head.Magic == "PSETMC", PrintBadFileMagic(fileName));
+                fldPresetData_Misc body[head.count];
+                break;
+            case "PreSetData_Party":
+                fldExcelCnvData head;
+                Assert(head.Magic == "PSETPA", PrintBadFileMagic(fileName));
+                fldPresetData_Party body[head.count];
+                break;
+            case "MapLink_Data":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MAPLIK", PrintBadFileMagic(fileName));
+                fldMapLink body[head.count];
+                break;
+            case "TravelPath":
+                fldExcelCnvData head;
+                Assert(head.Magic == "TRVPAT", PrintBadFileMagic(fileName));
+                fldTravelPath body[head.count];
+                break;
+            case "TravelPoint":
+                fldExcelCnvData head;
+                Assert(head.Magic == "TRVPOT", PrintBadFileMagic(fileName));
+                fldTravelPoint body[head.count];
+                break;
+            case "EnvLink":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ENVLINK", PrintBadFileMagic(fileName));
+                fldEnvLink body[head.count];
+                break;
+            case "CharaLink":
+                fldExcelCnvData head;
+                Assert(head.Magic == "Chara", PrintBadFileMagic(fileName));
+                fldCharaLink body[head.count];
+                break;
+            // init/data
+            case "AbilityTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ABL", PrintBadFileMagic(fileName));
+                initAbilityTable body[head.count];
+                break;
+            case "AddContentItemTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "TV", PrintBadFileMagic(fileName));
+                initAddContentItemTable body[head.count];
+                break;
+            case "AddContentTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "TV", PrintBadFileMagic(fileName));
+                initAddContentTable body[head.count];
+                break;
+            case "AreaName":
+                fldExcelCnvData head;
+                Assert(head.Magic == "AREA", PrintBadFileMagic(fileName));
+                initAreaName body[head.count];
+                break;
+            case "AreaNameLogo_Camp":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ARNMSPT", PrintBadFileMagic(fileName));
+                initAreaNameLogo_Camp body[head.count];
+                break;
+            case "AreaNameLogo_Event":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ARNMSPT", PrintBadFileMagic(fileName));
+                initAreaNameLogo_Event body[head.count];
+                break;
+            case "AreaNameLogo_Village":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ARNMSPT", PrintBadFileMagic(fileName));
+                initAreaNameLogo_Village body[head.count];
+                break;
+            case "ATCategoryTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ATC", PrintBadFileMagic(fileName));
+                initATCategoryTable body[head.count];
+                break;
+            case "BgMapData":
+                fldExcelCnvData head;
+                Assert(head.Magic == "BGMAPD", PrintBadFileMagic(fileName));
+                initBgMapData body[head.count];
+                break;
+            case "BountyCounter":
+                fldExcelCnvData head;
+                Assert(head.Magic == "BOUNTYC", PrintBadFileMagic(fileName));
+                initBountyCounter body[head.count];
+                break;
+            case "BountySpotTitleID":
+                fldExcelCnvData head;
+                Assert(head.Magic == "BOUNTYS", PrintBadFileMagic(fileName));
+                initBountySpotTitleID body[head.count];
+                break;
+            case "Calendar":
+                fldExcelCnvData head;
+                Assert(head.Magic == "CLD", PrintBadFileMagic(fileName));
+                initCalendar body[head.count];
+                break;
+            case "CalendarOpenMessage":
+                fldExcelCnvData head;
+                Assert(head.Magic == "CLDOPEN", PrintBadFileMagic(fileName));
+                initCalendarOpenMessage body[head.count];
+                break;
+            case "CharaID":
+                fldExcelCnvData head;
+                Assert(head.Magic == "CHARA", PrintBadFileMagic(fileName));
+                initCharaID body[head.count];
+                break;
+            case "CueToChannel":
+                fldExcelCnvData head;
+                Assert(head.Magic == "WIPE", PrintBadFileMagic(fileName));
+                initCueToChannel body[head.count];
+                break;
+            case "Daily":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DAILY", PrintBadFileMagic(fileName));
+                initDaily body[head.count];
+                break;
+            case "DebugFlagCounterSet":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DBCFLU", PrintBadFileMagic(fileName));
+                initDebugFlagCounterSet body[head.count];
+                break;
+            case "EnemyID":
+                fldExcelCnvData head;
+                Assert(head.Magic == "ENEMY", PrintBadFileMagic(fileName));
+                initEnemyID body[head.count];
+                break;
+            case "FadeColor":
+                fldExcelCnvData head;
+                Assert(head.Magic == "FDCOL", PrintBadFileMagic(fileName));
+                initFadeColor body[head.count];
+                break;
+            case "FOLLOWER_ITEM_EFFECT":
+                fldExcelCnvData head;
+                Assert(head.Magic == "FLWITM", PrintBadFileMagic(fileName));
+                initFollowerItemEffect body[head.count];
+                break;
+            case "FollowerCheckTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "FOLLOWR", PrintBadFileMagic(fileName));
+                initFollowerCheckTable body[head.count];
+                break;
+            case "FollowerLayout":
+                fldExcelCnvData head;
+                Assert(head.Magic == "FLWLYT", PrintBadFileMagic(fileName));
+                initFollowerLayout body[head.count];
+                break;
+            case "FollowerRankUp":
+                fldExcelCnvData head;
+                Assert(head.Magic == "FLWRUP", PrintBadFileMagic(fileName));
+                initFollowerRankUp body[head.count];
+                break;
+            case "FollowerTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "FOLLOWR", PrintBadFileMagic(fileName));
+                initFollowerTable body[head.count];
+                break;
+            case "GalicaTalkAkademeia":
+            case "GalicaTalkDungeon":
+            case "GalicaTalkFollower":
+            case "GalicaTalkScenario":
+                fldExcelCnvData head;
+                Assert(head.Magic == "GALICA", PrintBadFileMagic(fileName));
+                initGallicaTalk body[head.count];
+                break;
+            case "GalicaTalkPlayspot":
+                fldExcelCnvData head;
+                Assert(head.Magic == "GALICA", PrintBadFileMagic(fileName));
+                initGallicaTalkPlayspot body[head.count];
+                break;
+            case "GalicaTalkQuest":
+                fldExcelCnvData head;
+                Assert(head.Magic == "GALICA", PrintBadFileMagic(fileName));
+                initGallicaTalkQuest body[head.count];
+                break;
+            case "GalicaTalkTown":
+                fldExcelCnvData head;
+                Assert(head.Magic == "GALICA", PrintBadFileMagic(fileName));
+                initGallicaTalkTown body[head.count];
+                break;
+            case "KEISYO":
+                fldExcelCnvData head;
+                Assert(head.Magic == "KEISYO", PrintBadFileMagic(fileName));
+                initKEISYO body[head.count];
+                break;
+            case "LottoTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "LOTTBL", PrintBadFileMagic(fileName));
+                initLottoTable body[head.count];
+                break;
+            case "MapData":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MAPD", PrintBadFileMagic(fileName));
+                initMapData body[head.count];
+                break;
+            case "MapNameTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MAPNAME", PrintBadFileMagic(fileName));
+                initMapNameTable body[head.count];
+                break;
+            case "MapShortcut":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MAPSC", PrintBadFileMagic(fileName));
+                initMapShortcut body[head.count];
+                break;
+            case "MsgIcon_ATCategory":
+            case "MsgIcon_BadStatus":
+            case "MsgIcon_Equip":
+            case "MsgIcon_Item":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MSGICN", PrintBadFileMagic(fileName));
+                initMsgIcon body[head.count];
+                break;
+            case "newgameplus_DiscardItem":
+            case "newgameplus_KeepCounter":
+            case "newgameplus_KeepFlag":
+            case "newgameplus_KeepValuableItem":
+            case "newgameplus_ResetDefeatCountEnemy":
+                fldExcelCnvData head;
+                Assert(head.Magic == "NGPLUS", PrintBadFileMagic(fileName));
+                initNGPlus body[head.count];
+                break;
+            case "novel":
+                fldExcelCnvData head;
+                Assert(head.Magic == "NOVEL", PrintBadFileMagic(fileName));
+                initNovel body[head.count];
+                break;
+            case "NpcID":
+                fldExcelCnvData head;
+                Assert(head.Magic == "NPC", PrintBadFileMagic(fileName));
+                initNpcId body[head.count];
+                break;
+            case "PCParamTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "PCPARAM", PrintBadFileMagic(fileName));
+                initPcParamTable body[head.count];
+                break;
+            case "QuestDropTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "DROPTBL", PrintBadFileMagic(fileName));
+                initQuestDropTable body[head.count];
+                break;
+            case "QuestID":
+                fldExcelCnvData head;
+                Assert(head.Magic == "QUEST", PrintBadFileMagic(fileName));
+                initQuest body[head.count];
+                break;
+            case "QuestNpcLayout":
+                fldExcelCnvData head;
+                Assert(head.Magic == "QNPCL", PrintBadFileMagic(fileName));
+                initQuestNpcLayout body[head.count / 3]; // ??? (TODO)
+                break;
+            case "QuestProgression":
+                fldExcelCnvData head;
+                Assert(head.Magic == "NPC", PrintBadFileMagic(fileName));
+                initQuestProgression body[head.count];
+                break;
+            case "QuestRequiredItemsEx":
+                fldExcelCnvData head;
+                Assert(head.Magic == "EXITEM", PrintBadFileMagic(fileName));
+                initQuestRequiredItemsEx body[head.count * 8];
+                break;
+            case "QuestVoice":
+                fldExcelCnvData head;
+                Assert(head.Magic == "QSTVC", PrintBadFileMagic(fileName));
+                initQuestVoice body[head.count];
+                break;
+            case "QuestVoice2":
+                fldExcelCnvData head;
+                Assert(head.Magic == "QSTVC2", PrintBadFileMagic(fileName));
+                initQuestVoice2 body[head.count];
+                break;
+            case "ResrcNpcModelComb":
+            case "ResrcNpcModelCombEvent":
+                fldExcelCnvData head;
+                Assert(head.Magic == "MDLC", PrintBadFileMagic(fileName));
+                initResrcNpcModelComb body[head.count];
+                break;
+            case "resrcSndEnv":
+                fldExcelCnvData head;
+                Assert(head.Magic == "RSNDL", PrintBadFileMagic(fileName));
+                while (!FEof()) { initResrcSndEnv entry; }
+                break;
+            case "ShopTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "SHOP", PrintBadFileMagic(fileName));
+                initShopTable body[head.count];
+                break;
+            case "ShopTypeTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "SHOPTYP", PrintBadFileMagic(fileName));
+                initShopTypeTable body[head.count];
+                break;
+            case "SummonItemData":
+                fldExcelCnvData head;
+                Assert(head.Magic == "SMNER", PrintBadFileMagic(fileName));
+                initSummonItemData body[head.count];
+                break;
+            case "TravelersVoiceDTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "TV", PrintBadFileMagic(fileName));
+                initTravelersVoiceDTable body[head.count];
+                break;
+            case "TravelersVoiceTable":
+                fldExcelCnvData head;
+                Assert(head.Magic == "TV", PrintBadFileMagic(fileName));
+                initTravelersVoiceTable body[head.count];
+                break;
+            case "wipeAreaChangeData":
+                fldExcelCnvData head;
+                Assert(head.Magic == "WIPE", PrintBadFileMagic(fileName));
+                initWipeAreaChangeData body[head.count];
+                break;
+            case "wipeAreaChangeDataCategory":
+                fldExcelCnvData head;
+                Assert(head.Magic == "WIPE", PrintBadFileMagic(fileName));
+                initWipeAreaChangeDataCategory body[head.count];
+                break;
+            case "wipeData":
+                fldExcelCnvData head;
+                Assert(head.Magic == "WIPE", PrintBadFileMagic(fileName));
+                initWipeData body[head.count];
+                break;
+            default:
+                // check for DungeonGrid files
+                if (Strnicmp(fileName, "DungeonGrid", 11) == 0) {
+                    fldExcelCnvData head;
+                    Assert(head.Magic == "DGRID", PrintBadFileMagic(fileName));
+                    fldDungeonGrid_Data body[head.count];
+                } else if (Strnicmp(fileName, "PreSetData_Chara", 16 ) == 0) {
+                    fldExcelCnvData head;
+                    Assert(head.Magic == "PSETCH", PrintBadFileMagic(fileName));
+                    fldPresetData_Character body[head.count];
+                } else {
+                    Assert(false, Str("Unimplemented binary database %s", fileName));
+                }
+                break;
+        }
+        break;
     default:
         Assert(false, Str("Unimplemented file extension %s", fileExt));
         break;

--- a/templates/spritestudio_ssbp.bt
+++ b/templates/spritestudio_ssbp.bt
@@ -1,0 +1,270 @@
+//------------------------------------------------
+//--- 010 Editor v12.0.1 Binary Template
+//
+//      File: spritestudio_ssbp
+//   Authors: Rirurin
+//   Version: 0.1.0
+//   Purpose: 
+//  Category: 
+// File Mask: *.ssbp
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+// Part of the source code for Sprite Studio 6 is available at
+// https://github.com/SpriteStudio/SpriteStudio6-SDK
+
+#include "common/include.h"
+
+const u32 DATA_ID = 0x42505353;
+const u32 CURRENT_DATA_VERSION	= 11;
+
+typedef struct {
+    SetBackColorToShadeOfLastColor(0x10);
+    u32 offset;
+    FPushAbs(offset);
+    string text;
+    FPop();
+    SetBackColorToShadeOfLastColor(-0x10);
+} std_string<optimize=false, read=text>;
+
+typedef struct {
+    SetBackColorToShadeOfLastColor(0x10);
+    u32 offset;
+    FPushAbs(offset);
+    u32 unk;
+    std_string path;
+    std_string file;
+    FPop();
+    SetBackColorToShadeOfLastColor(-0x10);
+} string_filepath_project<read=file.text>;
+
+typedef struct {
+    SetBackColorToShadeOfLastColor(0x10);
+    u32 offset;
+    FPushAbs(offset);
+    std_string path;
+    std_string file;
+    FPop();
+    SetBackColorToShadeOfLastColor(-0x10);
+} string_filepath<read=file.text>;
+
+typedef struct {
+    u32 dataId<format=hex>;
+    Assert(dataId == DATA_ID);
+    u32 version;
+    Assert(version == CURRENT_DATA_VERSION);
+    u32 flags;
+    string_filepath_project imageBaseDir;
+    //u32 imageBaseDir;
+    u32 Cell;
+    u32 AnimePackData;
+    u32 EfffectFile;
+    u16 NumCells;
+    u16 NumAnimePacks;
+    u16 NumEffectFileList;
+    u16 NumSequencePacks;
+} ss_projectHeader<read=Str("%s: %d cells, %d anime packs, %d effect files, %d sequence packs", imageBaseDir.file.text, NumCells, NumAnimePacks, NumEffectFileList, NumSequencePacks)>;
+
+
+
+
+typedef struct {
+    SetRandomBackColor();
+    std_string name;
+    string_filepath imagePath;
+    u16 index;
+    u16 x;
+    u16 y;
+    u16 width;
+    u16 height;
+    u16 padding0<hidden=true>;
+    f32 pivot_x;
+    f32 pivot_y;
+    f32 u1;
+    f32 v1;
+    f32 u2;
+    f32 v2;
+} ss_cell<read=Str("%s @ %s, index %d, xy (%d x %d), wh (%d x %d)", name.text, imagePath.file.text, index, x, y, width, height)>;
+
+typedef struct(u32 offset, u32 count) {
+    FPushAbs(offset);
+    ss_cell data[count]<optimize=false>;
+    FPop();
+} ptr_cell;
+
+typedef struct {
+    SetBackColorToShadeOfLastColor(0x10);
+    std_string name;
+    u16 index;
+    u16 parentIndex;
+    u16 type;
+    u16 boundsType;
+    u16 alphaBlendType;
+    u16 padding;
+    std_string refName;
+    std_string effectName;
+    std_string colorLabel;
+    u16 maskInfluence;
+    u16 padding;
+    SetBackColorToShadeOfLastColor(-0x10);
+} ss_partData<read=Str("%s @ %d -> %d", name.text, index, parentIndex)>;
+
+typedef struct(u32 offset, u32 count) {
+    FPushAbs(offset);
+    ss_partData data[count]<optimize=false>;
+    FPop();
+} ptr_partData;
+
+typedef struct {
+    SetBackColorToShadeOfLastColor(0x20);
+    u16 index;
+    u32 lowflag;
+    u32 highflag;
+    u16 priority;
+    u16 cellIndex;
+    u16 opacity;
+    u16 localopacity;
+    u16 masklimen;
+    f32 positionX;
+    f32 positionY;
+    f32 positionZ;
+    f32 pivotX;
+    f32 pivotY;
+    f32 rotationX;
+    f32 rotationY;
+    f32 rotationZ;
+    f32 scaleX;
+    f32 scaleY;
+    f32 localscaleX;
+    f32 localscaleY;
+    f32 size_X;
+    f32 size_Y;
+    f32 uv_move_X;
+    f32 uv_move_Y;
+    f32 uv_rotation;
+    f32 uv_scale_X;
+    f32 uv_scale_Y;
+    f32 boundingRadius;
+    u32 unk;
+    u32 instanceValue_curKeyframe;
+    u32 instanceValue_startFrame;
+    u32 instanceValue_endFrame;
+    u32 instanceValue_loopNum;
+    f32 instanceValue_speed;
+    u32 instanceValue_loopflag;
+    u32 effectValue_curKeyframe;
+    u32 effectValue_startTime;
+    f32 effectValue_speed;
+    u32 effectValue_loopflag;
+    SetBackColorToShadeOfLastColor(-0x20);
+} ss_animationInitialData;
+
+typedef struct(u32 offset, u32 count) {
+    FPushAbs(offset);
+    ss_animationInitialData data[count]<optimize=false>;
+    FPop();
+} ptr_animationInitialData;
+
+typedef struct {
+    u32 ptr;
+    FPushAbs(ptr);
+    SetBackColorToShadeOfLastColor(0x10);
+    u16 index;
+    u16 padding<hidden=true>;
+    u32 flag1;
+    u32 flag2;
+    SetBackColorToShadeOfLastColor(-0x10);
+    FPop();
+} ss_frameDataIndex;
+
+typedef struct(u32 offset, u32 count) {
+    FPushAbs(offset);
+    ss_frameDataIndex data[count]<optimize=false>;
+    FPop();
+} ptr_frameDataIndex;
+
+typedef struct {
+} ss_userDataPerFrame;
+
+typedef struct {
+} ss_labelDataItem;
+
+typedef struct {
+    u32 uv;
+    FPushAbs(uv);
+    f32 uv;
+    FPop();
+} ss_meshDataUV;
+
+typedef struct(u32 offset, u32 count) {
+    FPushAbs(offset);
+    ss_meshDataUV data[count]<optimize=false>;
+    FPop();
+} ptr_meshDataUV;
+
+typedef struct {
+} ss_meshDataIndices;
+
+typedef struct {
+    SetBackColorToShadeOfLastColor(0x10);
+    std_string name;
+    u32 ptrdefaultData<hidden=true>;
+    u32 ptrframeData<hidden=true>;
+    u32 userData;
+    u32 labelData;
+    u32 meshdataUV;
+    u32 meshDataIndices;
+    u16 startFrames;
+    u16 endFrames;
+    u16 totalFrames;
+    u16 fps;
+    u16 labelNum;
+    u16 canvasSizeW;
+    u16 canvasSizeH;
+    u16 padding;
+    f32 canvasPivotX;
+    f32 canvasPivotY;
+    if (ptrdefaultData > 0) ptr_animationInitialData defaultData(ptrdefaultData, 2);
+    if (ptrframeData > 0) ptr_frameDataIndex frameData(ptrframeData, totalFrames);
+    if (meshdataUV > 0) ptr_meshDataUV meshDataUV(meshdataUV, 1);
+    SetBackColorToShadeOfLastColor(-0x10);
+} ss_animData<read=Str("%s", name.text)>;
+
+typedef struct(u32 offset, u32 count) {
+    FPushAbs(offset);
+    ss_animData data[count]<optimize=false>;
+    FPop();
+} ptr_animData;
+
+typedef struct {
+    SetRandomBackColor();
+    std_string name;
+    u32 ptrParts;
+    u32 ptrAnimations;
+    u16 partCount;
+    u16 animCount;
+    ptr_partData parts(ptrParts, partCount);
+    ptr_animData anim(ptrAnimations, animCount);
+} ss_anime<read=Str("%s, %d parts, %d anims", name.text, partCount, animCount)>;
+
+typedef struct(u32 offset, u32 count) {
+    FPushAbs(offset);
+    ss_anime data[count]<optimize=false>;
+    FPop();
+} ptr_anime;
+
+typedef struct {
+} ss_effectFileList;
+typedef struct {
+
+} ss_numSequencePacks;
+
+typedef struct {
+    SetRandomBackColor();
+    ss_projectHeader header;  
+    ptr_cell cells(header.Cell, header.NumCells);
+    ptr_anime anime(header.AnimePackData, header.NumAnimePacks);
+} ss_projectData<optimize=false>;
+
+ss_projectData entry;


### PR DESCRIPTION
This currently adds the following templates:
- `gfd_env.bt`: Currently only for Metaphor ENVs, but the intention is to add P5(R) support back into it
- `metaphor_evt_ecs.bt`: Event files for Metaphor. Same basic structure as P5's EVT
- `metaphor_fld.bt`: Supports a large amount of files used in fields (COMMON/field/source and COMMON/init/data)
- `spritestudio_ssbp.bt`: For binary SpriteStudio6 projects, used for sprites