### PR TITLE
update templates for 010 ver 16.0+

### DIFF
--- a/templates/p3p_enums.bt
+++ b/templates/p3p_enums.bt
@@ -1557,9 +1557,12 @@ enum<ushort>CharacterID
 enum<ushort>MusicID
 {
     MassDestruction = 0,
-    MasterOfShadow = 1,
-    UnavoidableBattle = 2,
-    MasterOfTartarus = 3,
+    MasterOfTartarus = 1,
+    MasterOfShadow = 2,
+    UnavoidableBattle = 3,
+    BurnMyDreadFinal = 4,
+    BattleHymnOfTheSoul = 5,
+    MasterOfTartarus_ = 6,
 	HeartfulCry = 7,
 	Darkness = 8,
 };

--- a/templates/p5d_eboot_music_table.bt
+++ b/templates/p5d_eboot_music_table.bt
@@ -1,0 +1,182 @@
+//------------------------------------------------
+//--- 010 Editor v9.0.2 Binary Template
+//
+//      File: 
+//   Authors: DeathChaos
+//   Version: 1.00
+//   Purpose: P5 Dan dancing exe music table
+//   History
+//   1.00    2024-04-23  DeathChaos - started this
+//------------------------------------------------
+
+
+LittleEndian();
+
+enum<uint>charID
+{
+    MainDancer = 0,
+	Yu = 1,
+	Yosuke = 2,
+	Chie = 3,
+	Yukiko = 4,
+	Rise = 5,
+	Kanji = 6,
+	Naoto = 7,
+	Teddie = 8,
+	Kanami = 9,
+	Nanako = 10,
+	Marie = 12,
+	Adachi = 13,
+	MakotoYuki = 101,
+	Yukari = 102,
+	Junpei = 103,
+	Akihiko = 104,
+	Mitsuru = 105,
+	Fuuka = 106,
+	Aigis = 107,
+	Ken = 108,
+	KoromaruDummy = 109,
+	Shinji = 110,
+	Elizabeth = 111,
+	Theodore = 112,
+	Labrys = 113,
+	MikuP3D = 114,
+	Sho = 115,
+	Margaret = 116,
+	Ren = 201,
+	Ryuji = 202,
+	Morgana = 203,
+	Ann = 204,
+	Yusuke = 205,
+	Makoto = 206,
+	Haru = 207,
+	Futaba = 208,
+	Akechi = 209,
+	Justine = 210,
+	Caroline = 211,
+	Lavenza = 212,
+};
+
+typedef struct
+{
+	int Bit0_SelectPartner : 1;
+	int Bit1_Makoto : 1;
+	int Bit2_Yukari : 1;
+	int Bit3_Junpei : 1;
+	int Bit4_Akihiko : 1;
+	int Bit5_Mitsuru : 1;
+	int Bit6_Fuuka : 1;
+	int Bit7_Aigis : 1;
+	int Bit8_Ken : 1;
+	int Bit9_Koro : 1;
+	int Bit10_Shinji : 1;
+	int Bit11_Elizabeth : 1;
+	int Bit12_Theodore : 1;
+	int Bit13_Labrys : 1;
+	int Bit14_Miku_P3 : 1;
+	int Bit15_Sho : 1;
+	int Bit16_Margaret : 1;
+	int Bit17 : 1;
+	int Bit18_Ren : 1;
+	int Bit19_Ryuji : 1;
+	int Bit20_Mona : 1;
+	int Bit21_Ann : 1;
+	int Bit22_Yusuke : 1;
+	int Bit23_Makoto : 1;
+	int Bit24_Haru : 1;
+	int Bit25_Futaba : 1;
+	int Bit26_Akechi : 1;
+	int Bit27_Justine : 1;
+	int Bit28_Caroline : 1;
+	int Bit29_Lavenza : 1;
+	int Bit30 : 1;
+	int Bit31 : 1;
+} SongBitsField30;
+
+typedef struct
+{
+	int Bit0_000 : 1;
+	int Bit1_Dummy : 1;
+	int Bit2_Yu : 1;
+	int Bit3_Yosuke : 1;
+	int Bit4_Chie : 1;
+	int Bit5_Yukiko : 1;
+	int Bit6_Rise : 1;
+	int Bit7_Kanji : 1;
+	int Bit8_Naoto : 1;
+	int Bit9_Teddie : 1;
+	int Bit10_Kanami : 1;
+	int Bit11_Nanako : 1;
+	int Bit12_Margaret : 1;
+	int Bit13_Marie : 1;
+	int Bit14_Adachi : 1;
+	int Bit15_Miku : 1;
+	int Bit16 : 1;
+	int Bit17 : 1;
+	int Bit18 : 1;
+	int Bit19 : 1;
+	int Bit20 : 1;
+	int Bit21 : 1;
+	int Bit22 : 1;
+	int Bit23 : 1;
+	int Bit24 : 1;
+	int Bit25 : 1;
+	int Bit26 : 1;
+	int Bit27 : 1;
+	int Bit28 : 1;
+	int Bit29 : 1;
+	int Bit30 : 1;
+	int Bit31 : 1;
+} SongBitsField34;
+
+typedef struct
+{
+  int isHideDancerArtistNameTex : 1;
+  int isDLC : 1;
+  int isGroupDance : 1;
+  int isHaveStageMaybe : 1;
+  int isSongHaveDancer : 1;
+  int SongBit_Bit05 : 1;
+  int isP3DSong : 1;
+  int isP5DSong : 1;
+} SongBits;
+
+typedef struct {
+	uint NamePTR;
+	SongBits Flags<format=hex>;
+	float BPM_1;
+	float BPM_2;
+	int Field10;
+	float Duration;
+	byte unk[4];
+	charID DancerID;
+	short Field20;
+	short Field22;
+	short Field24;
+	short Field26;
+	short Field28;
+	short Field2A;
+	short Field2C;
+	short Field2E;
+	SongBitsField30 Field30;
+	SongBitsField34 Field34;
+} SongData <optimize=false, read=GetName>;
+
+typedef struct {
+	int SongID;
+	int Flags;
+	short Field08;
+	short Field0A;
+	short Field0C;
+	short Field0E;
+	int linkedUnlocks[4];
+} SongUnlockData <optimize=false, read=Str("song %03d", this.SongID)>;
+
+typedef struct {
+	FSeek( 0x3C6250 );
+	SongData songs[89]<read=Str("%s - %s", EnumToString(this.DancerID), ReadString(this.NamePTR - 0x80FFEF20)) >;
+	FSeek( 0x3CF1E0 );
+	SongUnlockData unlock[87];
+} P5DEboot;
+
+P5DEboot SongTableData<name="Song Data Table">;

--- a/templates/p5r_BFL.bt
+++ b/templates/p5r_BFL.bt
@@ -1,0 +1,121 @@
+//------------------------------------------------
+//--- 010 Editor v11.0.1 Binary Template
+//
+//      File: 
+//   Authors: 
+//   Version: 
+//   Purpose: 
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+typedef char bool;
+typedef char s8;
+typedef uchar u8;
+typedef int16 s16;
+typedef uint16 u16;
+typedef int16 s16;
+typedef int32 s32;
+typedef uint32 u32;
+typedef int64 s64;
+typedef uint64 u64;
+typedef hfloat f16;
+typedef float f32;
+typedef double f64;
+
+typedef struct
+{
+	f32 x;
+	f32 y;
+
+} Vector2<optimize=false>;
+
+typedef struct
+{
+	f32 Float1;
+	f32 Float2;
+	f32 Float3;
+	f32 Float4;
+
+} Vector4<optimize=false>;
+
+
+enum<u8> Boolean
+{
+    False = false,
+    True = true,
+};
+
+typedef struct
+{
+	Boolean Active;
+	Vector2 Center;
+	s16 Rotate;
+	f32 Radius;
+	u8 Flags;
+	u8 Undefined3[3];
+} FormationUnit<optimize=false>;
+
+typedef struct
+{
+	Vector4 Eye;
+	Vector2 Target;
+	f32 Roll;
+	f32 FOV;
+} FormationCamera<optimize=false>;
+
+typedef struct
+{
+	u16 sizeS;
+	u16 sizeM;
+	u16 sizeL;
+	u16 Count;
+} FormationClassify<optimize=false>;
+
+typedef struct
+{
+	FormationUnit Player[4];
+	FormationUnit Enemy[5];
+	FormationClassify classify;
+	FormationCamera Command[4];
+} FormationList<optimize=false>;
+
+typedef struct
+{
+	FormationList list;
+} FormationCategory<optimize=false>;
+
+typedef struct
+{
+	FormationCategory Category[32];
+} FormationData<optimize=false>;
+
+typedef struct
+{
+	FormationCategory Normal;
+    FormationCategory Pinch;
+    FormationCategory HoldUp;
+    FormationCategory Advantage;
+    FormationCategory Intimidation;
+    if (version >= 0x01105080)
+    {
+        FormationCategory Unknown1;
+    }
+} FormationPack<optimize=false, read=NameRead>;
+
+string NameRead(FormationPack& block )
+{
+	char buffer[32];
+	SPrintf( buffer, "S: %.1d M: %.1d L: %.1d", block.Normal.list.classify.sizeS, block.Normal.list.classify.sizeM, block.Normal.list.classify.sizeL);
+	return buffer;
+}
+
+struct
+{
+    BigEndian();
+    u32 magic;    
+    u32 version;
+    u8 Undefined1[8];
+    FormationPack Pack[32];
+} Header<optimize=false>;

--- a/templates/p5r_BGMCND.bt
+++ b/templates/p5r_BGMCND.bt
@@ -247,8 +247,7 @@ struct FTDFile
 			byte unk2;
 			int16 unk3;
 			MusicID musicID;
-			int16 unk4;
-			int16 flagCondition;
+			int32 flagCondition<format=hex>;
 		}bgmcondblock[numOfEntries]<name="BGM Condition Blocks", read=GetFieldName>;
 		ubyte padd2[(0x10 - FTell() % 0x10) % 0x10]<name="padding">;
 	}bgmcondstruct<name="File">;
@@ -257,6 +256,6 @@ struct FTDFile
 string GetFieldName(BGMCondBlock &block)
 {
 	string buffer;
-    SPrintf( buffer, "field: %03d_%03d,  Time period: %02d/%02d - %02d/%02d, Flag: %05d, Music ID: %04d", block.fldMajorID, block.fldMinorID, block.monthStart, block.dayStart, block.monthEnd, block.dayEnd, block.flagCondition, block.musicID );
+    SPrintf( buffer, "field: %03d_%03d,  Time period: %02d/%02d - %02d/%02d, FlagCondition: 0x%08X, Music ID: %04d", block.fldMajorID, block.fldMinorID, block.monthStart, block.dayStart, block.monthEnd, block.dayEnd, block.flagCondition, block.musicID );
 	return buffer;
 }

--- a/templates/p5r_enums.bt
+++ b/templates/p5r_enums.bt
@@ -6476,6 +6476,13 @@ enum<ushort> MusicID
     RiversInTheDesert = 8,
     Yaldabaoth = 12,
     OurBeginning = 14,
+    KeepYourFaith = 15,
+    ThrowAwayYourMask = 16,
+    PrisonLabor= 17,
+    MassDestruction = 18,
+    ReachOutToTheTruth = 19,
+    TakeOver = 20,
+    ContinuePriorMusic = 99,
 };
 
 enum<byte> ArcanaID

--- a/templates/p5r_tbl.bt
+++ b/templates/p5r_tbl.bt
@@ -22,7 +22,7 @@ typedef ushort u16;
 typedef uint u32;
 typedef float f32;
 
-enum<byte>bool
+enum<byte>u8
 {
     False = 0,
     True = 1,
@@ -30,143 +30,144 @@ enum<byte>bool
 
 typedef struct
 {
-    u8 bit0 : 1;
-    u8 bit1 : 1;
-    u8 bit2 : 1;
-    u8 bit3 : 1;
-    u8 bit4 : 1;
-    u8 bit5 : 1;
-    u8 bit6 : 1;
     u8 bit7 : 1;
-} b8;
+    u8 bit6 : 1;
+    u8 bit5 : 1;
+    u8 bit4 : 1;
+    u8 bit3 : 1;
+    u8 bit2 : 1;
+    u8 bit1 : 1;
+    u8 bit0 : 1;
+} b8<edit=flags>;
 
 typedef struct
 {
-    u8 nonbegging : 1 <name = "No Begging Shadows", comment = "Enemies will never beg regardless of their personality (Meaning, it is as if it's always irritable)">;
-    u8 hidingstatus : 1 <name = "Hiding the status", comment = "Enemies status can be hidden similar to boss">;
-    u8 bit2 : 1;
-    u8 bit3 : 1;
-    u8 GuaranteePersonaMask : 1 <name = "Guarantee Persona Mask", comment = "For some reason, turning this on will make the shadow has drop coin effect and shadow visual appearance. It will also no longer return to battle after obtaining Persona.">;
-    u8 nonnegotiable : 1 <name = "Not negotiable", comment = "Enemies will never be able to negotiate">;
-    u8 bit6 : 1;
-    u8 bit7 : 1;
-    u8 bit8 : 1;
-    u8 bit9 : 1;
-    u8 bit10 : 1;
-    u8 bit11 : 1;
-    u8 bit12 : 1;
-    u8 hidingstatus2 : 1 <name = "Hiding the status", comment = "Enemies status can be hidden similar to boss. This is used on Boss">;
-    u8 infiniteSP : 1 <name = "Infinite SP", comment = "Enemies will be able to use any skill regardless of SP pool">;
+    u8 nonbegging : 1 <name = "No Begging Shadows (bit 15)", comment = "Enemies will never beg regardless of their personality (Meaning, it is as if it's always irritable)">;
+    u8 hidingstatus : 1 <name = "Hiding the status (bit 14)", comment = "Enemies status can be hidden similar to boss">;
     u8 bit13 : 1;
+    u8 bit12 : 1;
+    u8 GuaranteePersonaMask : 1 <name = "Guarantee Persona Mask (bit 11)", comment = "For some reason, turning this on will make the shadow has drop coin effect and shadow visual appearance. It will also no longer return to battle after obtaining Persona.">;
+    u8 nonnegotiable : 1 <name = "Not negotiable (bit 10)", comment = "Enemies will never be able to negotiate">;
+    u8 bit9 : 1;
+    u8 bit8 : 1;
+    u8 bit7 : 1;
+    u8 bit6 : 1;
+    u8 bit5 : 1;
+    u8 bit4 : 1;
+    u8 bit3 : 1;
+    u8 hidingstatus2 : 1 <name = "Hiding the status(bit 2)", comment = "Enemies status can be hidden similar to boss. This is used on Boss">;
+    u8 infiniteSP : 1 <name = "Infinite SP (bit 1)", comment = "Enemies will be able to use any skill regardless of SP pool">;
+    u8 bit0 : 1;
 } b16;
 
 typedef struct
 {
-    u8 bit0 : 1;
-    u8 bit1 : 1;
-    u8 bit2 : 1;
-    u8 bit3 : 1;
-    u8 bit4 : 1;
-    u8 bit5 : 1;
-    u8 bit6 : 1;
-    u8 bit7 : 1;
-    u8 bit8 : 1;
-    u8 bit9 : 1;
-    u8 bit10 : 1;
-    u8 bit11 : 1;
-    u8 bit12 : 1;
-    u8 bit13 : 1;
-    u8 bit14 : 1;
-    u8 bit15 : 1;
-    u8 nonbegging : 1 <name = "No Begging Shadows", comment = "Enemies will never beg regardless of their personality (Meaning, it is as if it's always irritable)">;
-    u8 hidingstatus : 1 <name = "Hiding the status", comment = "Enemies status can be hidden similar to boss">;
-    u8 bit18 : 1;
-    u8 bit19 : 1;
-    u8 GuaranteePersonaMask : 1 <name = "Guarantee Persona Mask", comment = "For some reason, turning this on will make the shadow has drop coin effect and shadow visual appearance. It will also no longer return to battle after obtaining Persona.">;
-    u8 nonnegotiable : 1 <name = "Not negotiable", comment = "Enemies will never be able to negotiate">;
-    u8 bit22 : 1;
-    u8 bit23 : 1;
-    u8 bit24 : 1;
-    u8 bit25 : 1;
-    u8 bit26 : 1;
-    u8 bit27 : 1;
-    u8 bit28 : 1;
-    u8 hidingstatus2 : 1 <name = "Hiding the status", comment = "Enemies status can be hidden similar to boss. This is used on Boss">;
-    u8 infiniteSP : 1 <name = "Infinite SP", comment = "Enemies will be able to use any skill regardless of SP pool">;
     u8 bit31 : 1;
-} b32_unit;
+    u8 bit30 : 1;
+    u8 bit29 : 1;
+    u8 bit28 : 1;
+    u8 bit27 : 1;
+    u8 bit26 : 1;
+    u8 bit25 : 1;
+    u8 bit24 : 1;
+    u8 bit23 : 1;
+    u8 bit22 : 1;
+    u8 bit21 : 1;
+    u8 bit20 : 1;
+    u8 bit19 : 1;
+    u8 bit18 : 1;
+    u8 savage : 1 <name = "Is Savage Enemy (bit 17)", comment ="Enemy will not negotiate until at 25% health or less">;
+    u8 bit16 : 1;
+    u8 nonbegging : 1 <name = "No Begging Shadows (bit 15)", comment = "Enemies will never beg regardless of their personality (Meaning, it is as if it's always irritable)">;
+    u8 hidestats : 1 <name = "Hide stats on analysis screen (bit 14)", comment = "Enemies status can be hidden similar to boss">;
+    u8 bit13 : 1;
+    u8 bit12 : 1;
+    u8 treasuredemon : 1 <name = "Is Treasure Demon (bit 11)", comment = "Enemy acts as Treasure Demon, dropping coins and guaranteeing its Persona mask">;
+    u8 nonnegotiable : 1 <name = "Not negotiable (bit 10)", comment = "Enemies will never be able to negotiate">;
+    u8 nocrit : 1 <name = "Disable Critical(bit 9)", comment ="Skills will never land a Critical hit on the enemy" >;
+    u8 bit8 : 1;
+    u8 downshot : 1 <name = "Disable Down Shot (bit 7)", comment = "Down Shot will always miss" >;
+    u8 bit6 : 1;
+    u8 bit5 : 1;
+    u8 bit4 : 1;
+    u8 bit3 : 1;
+    u8 hidestatsboss : 1 <name = "Hide stats/No disappearing when defeated (bit 2)", comment = "Status screen hides skills/stats. Used for bosses, loads special name graphic if the enemy has one (this is hardcoded to their ID).">;
+    u8 infiniteSP : 1 <name = "Infinite SP (bit 1)", comment = "Enemies will be able to use any skill regardless of SP pool">;
+    u8 bit0 : 1;
+} b32_unit<edit=flags>;
 
 typedef struct
 {
-    u8 bit0 : 1;
-    u8 bit1 : 1;
-    u8 bit2 : 1;
-    u8 bit3 : 1;
-    u8 bit4 : 1;
-    u8 bit5 : 1;
-    u8 bit6 : 1;
-    u8 bit7 : 1;
-    u8 bit8 : 1;
-    u8 bit9 : 1;
-    u8 bit10 : 1;
-    u8 bit11 : 1;
-    u8 NonNegotiable : 1 <name = "No Negotiation", comment = "If this turns on, every enemy in that battle can't be negotiated">;
-    u8 bit13 : 1;
-    u8 bit14 : 1;
-    u8 bit15 : 1;
-    u8 PreventKnockdown : 1 <name = "Prevent Knockdown", comment = "Enemy can never get knockdown 100% by Critical but not WEAK">;
-    u8 PositionHack : 1 <name = "Position Hack", comment = "Triggers Position Hack when you enter the battle">;
-    u8 NoHoldUp : 1 <name = "No Hold Up", comment = "Hold up after downing all enemies will not trigger">;
-    u8 shadownotdisappearinbattle : 1 <name = "Not Disappear in Battle", comment = "When the shadow HP reaches 0, it will not disperse if this is turned ON in ENCOUNT.TBL Flag">;
-    u8 BulletHailonstart : 1 <name = "Bullet Hail on Start", comment = "When you start the battle, you will always start with Bullet Hail">;
-    u8 NoNavigator : 1 <name = "No Navigator in Battle", comment = "This disables Navigator in battle">;
-    u8 bit22 : 1;
-    u8 loadbattlescript : 1 <name = "Battle script load", comment = "This will load the battle script for this particular battle (CAUTION: Will cause freeze if the battle script file is not exist)">;
-    u8 bit24 : 1;
-    u8 bit25 : 1;
-    u8 loadbattlescript2 : 1 <name = "BFL Battle script load", comment = "This will load the battle script including Battle Formation for this particular battle (CAUTION: Will cause freeze if the battle script file is not exist)">;
-    u8 EnemyFirstAct : 1 <name = "Enemy First Act", comment = "This will cause all enemies to act first turn as if party got ambushed. (Whether it must be scripted or random encounter is still unknown.">;
-    u8 NoCritical : 1 <name = "No Critical", comment = "Even if you have a skill with 100% Critical, it will never trigger critical if this is ON">;
-    u8 bit29 : 1;
+    u8 bit31 : 1;
     u8 bit30 : 1;
-    u8 NoEscape : 1 <name = "No Escape", comment = "This will make your battle unescapable if it is ON">;
+    u8 bit29 : 1;
+    u8 bit28 : 1;
+    u8 bit27 : 1;
+    u8 bit26 : 1;
+    u8 bit25 : 1;
+    u8 bit24 : 1;
+    u8 bit23 : 1;
+    u8 bit22 : 1;
+    u8 bit21 : 1;
+    u8 bit20 : 1;
+    u8 NonNegotiable : 1 <name = "No Negotiation (bit 19)", comment = "If this turns on, every enemy in that battle can't be negotiated">;
+    u8 bit18 : 1;
+    u8 bit17 : 1;
+    u8 bit16 : 1;
+    u8 PreventKnockdown : 1 <name = "Prevent Knockdown (bit 15)", comment = "Enemy can never get knockdown 100% by Critical but not WEAK">;
+    u8 PositionHack : 1 <name = "Position Hack (bit 14)", comment = "Triggers Position Hack when you enter the battle">;
+    u8 NoHoldUp : 1 <name = "No Hold Up (bit 13)", comment = "Hold up after downing all enemies will not trigger">;
+    u8 shadownotdisappearinbattle : 1 <name = "Not Disappear in Battle (bit 12)", comment = "When the shadow HP reaches 0, it will not disperse if this is turned ON in ENCOUNT.TBL Flag">;
+    u8 BulletHailonstart : 1 <name = "Bullet Hail on Start (bit 11)", comment = "When you start the battle, you will always start with Bullet Hail">;
+    u8 NoNavigator : 1 <name = "No Navigator in Battle (bit 10)", comment = "This disables Navigator in battle">;
+    u8 bit9 : 1;
+    u8 loadbattlescript : 1 <name = "Battle script load (bit 8)", comment = "This will load the battle script for this particular battle (CAUTION: Will cause freeze if the battle script file is not exist)">;
+    u8 bit7 : 1;
+    u8 bit6 : 1;
+    u8 loadbattlescript2 : 1 <name = "BFL Battle script load (bit 5)", comment = "This will load the battle script including Battle Formation for this particular battle (CAUTION: Will cause freeze if the battle script file is not exist)">;
+    u8 EnemyFirstAct : 1 <name = "Enemy First Act (bit 4)", comment = "This will cause all enemies to act first turn as if party got ambushed. (Whether it must be scripted or random encounter is still unknown.">;
+    u8 NoCritical : 1 <name = "No Critical (bit 3)", comment = "Even if you have a skill with 100% Critical, it will never trigger critical if this is ON">;
+    u8 bit2 : 1;
+    u8 bit1 : 1;
+    u8 NoEscape : 1 <name = "No Escape (bit 0)", comment = "This will make your battle unescapable if it is ON">;
 } b32;
 
+
 typedef struct
 {
-    bool Unknown : 1 <name = "Unknown">;
-    bool Unknown : 1 <name = "Unknown">;
-    bool Gift : 1 <name = "Gift">;
-    bool CraftingMaterial : 1 <name = "Crafting Material">;
-    bool DungeonItem : 1 <name = "Dungeon Item">;
-    bool Outfit : 1 <name = "Outfit">;
-    bool SkillCard : 1 <name = "Skill Card">;
-    bool Treasure : 1 <name = "Treasure">;
-    bool KeyItem : 1 <name = "Key Item">;
-    bool Consumable : 1 <name = "Consumable">;
-    bool Accessory : 1 <name = "Accessory">;
-    bool Armor : 1 <name = "Armor">;
-    bool Unknown : 1 <name = "Unknown">;
-    bool LAR : 1 <name = "Lever-Action Rifle (Kasumi)">;
-    bool ToyGun : 1 <name = "Toy Gun (Akechi)">;
-    bool GL : 1 <name = "Grenade Launcher (Haru)">;
-    bool Revolver : 1 <name = "Revolver (Makoto)">;
-    bool AR : 1 <name = "Assault Rifle (Yusuke)">;
-    bool Slingshot : 1 <name = "Slingshot (Morgana)">;
-    bool SMG : 1 <name = "SMG (Ann)">;
-    bool Shotgun : 1 <name = "Shotgun (Ryuji)">;
-    bool Handgun : 1 <name = "Handgun (Joker)">;
-    bool Unknown : 1 <name = "Unknown">;
-    bool Rapier : 1 <name = "Rapier (Kasumi)">;
-    bool BeamSword : 1 <name = "Beam Sword (Goro)">;
-    bool Axe : 1 <name = "Axe (Haru)">;
-    bool FistWeapons : 1 <name = "Fist Weapons (Makoto)">;
-    bool Katana : 1 <name = "Katana (Yusuke)">;
-    bool BanditSword : 1 <name = "Bandit Sword (Morgana)">;
-    bool Whip : 1 <name = "Whip (Ann)">;
-    bool Crowbar : 1 <name = "Crowbar (Ryuji)">;
-    bool Dagger : 1 <name = "Dagger (Joker)">;
-} ItemType <name = "Icon">;
+    u8 Unknown : 1 <name = "Unknown">;
+    u8 Unknown : 1 <name = "Unknown">;
+    u8 Gift : 1 <name = "Gift">;
+    u8 CraftingMaterial : 1 <name = "Crafting Material">;
+    u8 DungeonItem : 1 <name = "Dungeon Item">;
+    u8 Outfit : 1 <name = "Outfit">;
+    u8 SkillCard : 1 <name = "Skill Card">;
+    u8 Treasure : 1 <name = "Treasure">;
+    u8 KeyItem : 1 <name = "Key Item">;
+    u8 Consumable : 1 <name = "Consumable">;
+    u8 Accessory : 1 <name = "Accessory">;
+    u8 Armor : 1 <name = "Armor">;
+    u8 Unknown : 1 <name = "Unknown">;
+    u8 LAR : 1 <name = "Lever-Action Rifle (Kasumi)">;
+    u8 ToyGun : 1 <name = "Toy Gun (Akechi)">;
+    u8 GL : 1 <name = "Grenade Launcher (Haru)">;
+    u8 Revolver : 1 <name = "Revolver (Makoto)">;
+    u8 AR : 1 <name = "Assault Rifle (Yusuke)">;
+    u8 Slingshot : 1 <name = "Slingshot (Morgana)">;
+    u8 SMG : 1 <name = "SMG (Ann)">;
+    u8 Shotgun : 1 <name = "Shotgun (Ryuji)">;
+    u8 Handgun : 1 <name = "Handgun (Joker)">;
+    u8 Unknown : 1 <name = "Unknown">;
+    u8 Rapier : 1 <name = "Rapier (Kasumi)">;
+    u8 BeamSword : 1 <name = "Beam Sword (Goro)">;
+    u8 Axe : 1 <name = "Axe (Haru)">;
+    u8 FistWeapons : 1 <name = "Fist Weapons (Makoto)">;
+    u8 Katana : 1 <name = "Katana (Yusuke)">;
+    u8 BanditSword : 1 <name = "Bandit Sword (Morgana)">;
+    u8 Whip : 1 <name = "Whip (Ann)">;
+    u8 Crowbar : 1 <name = "Crowbar (Ryuji)">;
+    u8 Dagger : 1 <name = "Dagger (Joker)">;
+} ItemType <edit=flags, name = "Icon">;
 
 
 //---------------------------------------------
@@ -629,10 +630,10 @@ typedef struct()
 
     struct
         {
-            byte : 6;
-            bool Enemies : 1 <name = "Enemies">;
-            bool Allies : 1 <name = "Allies">;
-        } ValidTargets <name = "Valid Targets">;
+            u8 : 6;
+            u8 Enemies : 1 <name = "Enemies">;
+            u8 Allies : 1 <name = "Allies">;
+        } ValidTargets <edit=flags,name = "Valid Targets">;
     
     Skill_TargetRestrictions TargetRestrictions <name = "Additional Target Restrictions">;
     u8 Unknown <name = "Unknown">;
@@ -654,87 +655,87 @@ typedef struct()
 
    struct
         {
-            bool Counter : 1 <name = "Counter?", comment = "it may be possibly counter mode exclusive to Yaldabaoth">;
-            bool Mouse : 1 <name = "Mouse", comment = "Only affects the Phantom Thieves">;
-            bool Gluttony : 1 <name = "Gluttony?", comment = "it may be possibly Gluttony ailment exclusive to Yaldabaoth">;
-            bool KnockDown : 1 <name = "Knock Down">;
-            bool Unconscious : 1 <name = "Unconscious">;
-            bool WeakToAllElements : 1 <name = "Weak to all Elements", comment = "Shock,Knockdown,Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
-            bool Jealousy : 1 <name = "Jealousy">;
-            bool Wrath : 1 <name = "Wrath">;
-        } Effect1 <name = "Effect List 1">;
+            u8 Counter : 1 <name = "Counter?", comment = "it may be possibly counter mode exclusive to Yaldabaoth">;
+            u8 Mouse : 1 <name = "Mouse", comment = "Only affects the Phantom Thieves">;
+            u8 Gluttony : 1 <name = "Gluttony?", comment = "it may be possibly Gluttony ailment exclusive to Yaldabaoth">;
+            u8 KnockDown : 1 <name = "Knock Down">;
+            u8 Unconscious : 1 <name = "Unconscious">;
+            u8 WeakToAllElements : 1 <name = "Weak to all Elements", comment = "Shock,Knockdown,Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
+            u8 Jealousy : 1 <name = "Jealousy">;
+            u8 Wrath : 1 <name = "Wrath">;
+        } Effect1 <edit=flags,name = "Effect List 1">;
 
     struct
         {
-            bool Lust : 1 <name = "Lust", comment = "Lust, Rage, Berserk can be combined into 1 single ailment">;
-            bool Panic : 1 <name = "Panic", comment = "Will cause Shadows to run away">;
-            bool Berserk : 1 <name = "Berserk", comment = "Visual effect only. Also, Lust, Rage, Berserk can be combined into 1 single ailment">;
-            bool Desparation : 1 <name = "Desparation", comment = "Attack up, Defense down; not affected by other buffs/debuffs">;
-            bool Brainwash : 1 <name = "Brainwash">;
-            bool Despair : 1 <name = "Despair", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
-            bool Rage : 1 <name = "Rage", comment = "Lust, Rage, Berserk can be combined into 1 single ailment">;
-            bool Sleep : 1 <name = "Sleep", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
-        } Effect2 <name = "Effect List 2">;
+            u8 Lust : 1 <name = "Lust", comment = "Lust, Rage, Berserk can be combined into 1 single ailment">;
+            u8 Panic : 1 <name = "Panic", comment = "Will cause Shadows to run away">;
+            u8 Berserk : 1 <name = "Berserk", comment = "Visual effect only. Also, Lust, Rage, Berserk can be combined into 1 single ailment">;
+            u8 Desparation : 1 <name = "Desparation", comment = "Attack up, Defense down; not affected by other buffs/debuffs">;
+            u8 Brainwash : 1 <name = "Brainwash">;
+            u8 Despair : 1 <name = "Despair", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
+            u8 Rage : 1 <name = "Rage", comment = "Lust, Rage, Berserk can be combined into 1 single ailment">;
+            u8 Sleep : 1 <name = "Sleep", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
+        } Effect2 <edit=flags,name = "Effect List 2">;
 
    struct
         {
-            bool Hunger : 1 <name = "Hunger", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
-            bool Forget : 1 <name = "Forget", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
-            bool Fear : 1 <name = "Fear", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
-            bool Confuse : 1 <name = "Confuse", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
-            bool Dizzy : 1 <name = "Dizzy", comment = "Dizzy, Weakness and Knockdown can be combined into 1 single ailment">;
-            bool Shock : 1 <name = "Shock", comment = "Shock, Weakness and Knockdown can be combined into 1 single ailment">;
-            bool Freeze : 1 <name = "Freeze", comment = "Burn and Freeze can be combined into 1 single ailment">;
-            bool Burn : 1 <name = "Burn", comment = "Burn and Freeze can be combined into 1 single ailment">;
-        } Effect3 <name = "Effect List 3">;
+            u8 Hunger : 1 <name = "Hunger", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
+            u8 Forget : 1 <name = "Forget", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
+            u8 Fear : 1 <name = "Fear", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
+            u8 Confuse : 1 <name = "Confuse", comment = "Sleep,Hunger,Forget,Fear,Confuse,Weak,Despair can be combined into 1 single ailment">;
+            u8 Dizzy : 1 <name = "Dizzy", comment = "Dizzy, Weakness and Knockdown can be combined into 1 single ailment">;
+            u8 Shock : 1 <name = "Shock", comment = "Shock, Weakness and Knockdown can be combined into 1 single ailment">;
+            u8 Freeze : 1 <name = "Freeze", comment = "Burn and Freeze can be combined into 1 single ailment">;
+            u8 Burn : 1 <name = "Burn", comment = "Burn and Freeze can be combined into 1 single ailment">;
+        } Effect3 <edit=flags, name = "Effect List 3">;
 
    struct
         {
-            bool CoverPsy : 1 <name = "Cover Psy Weakness", comment = "Changes innate Psy weakness to neutral">;
-            bool CoverNuke : 1 <name = "Cover Nuke Weakness", comment = "Changes innate Nuke weakness to neutral">;
-            bool CoverWind : 1 <name = "Cover Wind Weakness", comment = "Changes innate Wind weakness to neutral">;
-            bool CoverElec : 1 <name = "Cover Electric Weakness", comment = "Changes innate Electric weakness to neutral">;
-            bool CoverIce : 1 <name = "Cover Ice Weakness", comment = "Changes innate Ice weakness to neutral">;
-            bool CoverFire : 1 <name = "Cover Fire Weakness", comment = "Changes innate Fire weakness to neutral">;
-            bool InstakillShield : 1 <name = "Instakill Shield", comment = "Blocks one instakill attack">;
-            bool BreakMagicShield : 1 <name = "Break Magic Shield", comment = "Breaks magic-reflecting shields like Makarakarn">;
-        } Effect4 <name = "Effect List 4">;
+            u8 CoverPsy : 1 <name = "Cover Psy Weakness", comment = "Changes innate Psy weakness to neutral">;
+            u8 CoverNuke : 1 <name = "Cover Nuke Weakness", comment = "Changes innate Nuke weakness to neutral">;
+            u8 CoverWind : 1 <name = "Cover Wind Weakness", comment = "Changes innate Wind weakness to neutral">;
+            u8 CoverElec : 1 <name = "Cover Electric Weakness", comment = "Changes innate Electric weakness to neutral">;
+            u8 CoverIce : 1 <name = "Cover Ice Weakness", comment = "Changes innate Ice weakness to neutral">;
+            u8 CoverFire : 1 <name = "Cover Fire Weakness", comment = "Changes innate Fire weakness to neutral">;
+            u8 InstakillShield : 1 <name = "Instakill Shield", comment = "Blocks one instakill attack">;
+            u8 BreakMagicShield : 1 <name = "Break Magic Shield", comment = "Breaks magic-reflecting shields like Makarakarn">;
+        } Effect4 <edit=flags, name = "Effect List 4">;
 
    struct
         {
-            bool BreakPhysicalShield : 1 <name = "Break Physical Shield", comment = "Breaks physical-reflecting shields like Tetrakarn">;
-            bool AilmentSusceptibility : 1 <name = "Ailment Susceptibility", comment = "increases the likelihood of recieving effects from Effect Lists 2 and 3">;
-            bool NegatePsyResist : 1 <name = "Negate Psy Resistance", comment = "Changes innate Psy resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
-            bool NegateNukeResist : 1 <name = "Negate Nuke Resistance", comment = "Changes innate Nuke resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
-            bool NegateWindResist : 1 <name = "Negate Wind Resistance", comment = "Changes innate Wind resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
-            bool NegateElecResist : 1 <name = "Negate Electric Resistance", comment = "Changes innate Electric resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
-            bool NegateIceResist : 1 <name = "Negate Ice Resistance", comment = "Changes innate Ice resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
-            bool NegateFireResist : 1 <name = "Negate Fire Resistance", comment = "Changes innate Fire resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
-        } Effect5 <name = "Effect List 5">;
+            u8 BreakPhysicalShield : 1 <name = "Break Physical Shield", comment = "Breaks physical-reflecting shields like Tetrakarn">;
+            u8 AilmentSusceptibility : 1 <name = "Ailment Susceptibility", comment = "increases the likelihood of recieving effects from Effect Lists 2 and 3">;
+            u8 NegatePsyResist : 1 <name = "Negate Psy Resistance", comment = "Changes innate Psy resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
+            u8 NegateNukeResist : 1 <name = "Negate Nuke Resistance", comment = "Changes innate Nuke resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
+            u8 NegateWindResist : 1 <name = "Negate Wind Resistance", comment = "Changes innate Wind resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
+            u8 NegateElecResist : 1 <name = "Negate Electric Resistance", comment = "Changes innate Electric resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
+            u8 NegateIceResist : 1 <name = "Negate Ice Resistance", comment = "Changes innate Ice resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
+            u8 NegateFireResist : 1 <name = "Negate Fire Resistance", comment = "Changes innate Fire resistance to neutral; does not override Cover Weakness effects from Effect List 4">;
+        } Effect5 <edit=flags, name = "Effect List 5">;
 
    struct
         {
-            bool MagicShield : 1 <name = "Magic Shield", comment = "Reflects the next magic attack received">;
-            bool PhysicalShield : 1 <name = "Physical Shield", comment = "Reflects the next physical attack received">;
-            bool CritWayUp : 1 <name = "Critical Chance Way Up">;
-            bool CritUp : 1 <name = "Critical Chance Up">;
-            bool RemoveDebuffs : 1 <name = "Remove Debuffs", comment = "Removes stat-lowering debuffs from the Buff/Debuff List">;
-            bool RemoveBuffs : 1 <name = "Remove Buffs", comment = "Removes stat-raising buffs from the Buff/Debuff List">;
-            bool Concentrate : 1 <name = "Concentrate", comment = "Next Magic-based attack deals 2.5x damage">;
-            bool Charge : 1 <name = "Charge", comment = "Next Strength-based attack deals 2.5x damage">;
-        } Effect6 <name = "Effect List 6">;
+            u8 MagicShield : 1 <name = "Magic Shield", comment = "Reflects the next magic attack received">;
+            u8 PhysicalShield : 1 <name = "Physical Shield", comment = "Reflects the next physical attack received">;
+            u8 CritWayUp : 1 <name = "Critical Chance Way Up">;
+            u8 CritUp : 1 <name = "Critical Chance Up">;
+            u8 RemoveDebuffs : 1 <name = "Remove Debuffs", comment = "Removes stat-lowering debuffs from the Buff/Debuff List">;
+            u8 RemoveBuffs : 1 <name = "Remove Buffs", comment = "Removes stat-raising buffs from the Buff/Debuff List">;
+            u8 Concentrate : 1 <name = "Concentrate", comment = "Next Magic-based attack deals 2.5x damage">;
+            u8 Charge : 1 <name = "Charge", comment = "Next Strength-based attack deals 2.5x damage">;
+        } Effect6 <edit=flags, name = "Effect List 6">;
 
     struct
         {
-            bool AccuracyDown : 1 <name = "Accuracy Down">;
-            bool AccuracyUp : 1 <name = "Accuracy Up">;
-            bool DefenseDown : 1 <name = "Defense Down">;
-            bool DefenseUp : 1 <name = "Defense Up">;
-            bool EvasionDown : 1 <name = "Evasion Down">;
-            bool EvasionUp : 1 <name = "Evasion Up">;
-            bool AttackDown : 1 <name = "Attack Down">;
-            bool AttackUp : 1 <name = "Attack Up">;
-        } BuffDebuff <name = "Buffs and Debuffs">;
+            u8 AccuracyDown : 1 <name = "Accuracy Down">;
+            u8 AccuracyUp : 1 <name = "Accuracy Up">;
+            u8 DefenseDown : 1 <name = "Defense Down">;
+            u8 DefenseUp : 1 <name = "Defense Up">;
+            u8 EvasionDown : 1 <name = "Evasion Down">;
+            u8 EvasionUp : 1 <name = "Evasion Up">;
+            u8 AttackDown : 1 <name = "Attack Down">;
+            u8 AttackUp : 1 <name = "Attack Up">;
+        } BuffDebuff <edit=flags, name = "Buffs and Debuffs">;
 
     u8 UnknownR;
     u16 RESERVE_2A;
@@ -743,7 +744,7 @@ typedef struct()
     u8 CritChance <name = "Crit Chance", comment = "Only works for Physical or Gun skills">;
     u8 ForItem <name = "For Item?", comment = "Not sure what this does since it has 20 value on Firecracker, Magatama item">;
     u8 Unknown <name = "Unknown">;
-} TSkill_ActiveSkillData <name="Active Skill Data", read=Str("Base Damage - %03d", this.BaseDamage)>;
+} TSkill_ActiveSkillData <name="Active Skill Data">;
 
 typedef struct
 {


### PR DESCRIPTION
Updated p5r_tbl to use new features from 010 version 16.0 (or newer) such as having checkboxes on bitfields.

<img width="525" height="461" alt="image" src="https://github.com/user-attachments/assets/719f82f0-f3ca-49be-a083-3238c176b6fa" />
